### PR TITLE
Add heat demand sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ dynamic_heat_curve_prediction:
   - `indoor_temperature_forecast`: voorspelde binnentemperatuur
   - (toekomstig) `predicted_savings`: verwachte energiekostenbesparing
 
+### `sensor.hourly_heat_loss`
+- Berekend warmteverlies van de woning in kW
+
+### `sensor.hourly_solar_gain`
+- Verwachte zonnewinst in kW
+
+### `sensor.hourly_net_heat_demand`
+- Netto warmtevraag na aftrek van zonwinst in kW
+
 ---
 
 ## 🧮 Berekening
@@ -161,6 +170,9 @@ Voeg de volgende sensoren toe aan je Lovelace-dashboard:
 - `sensor.outdoor_temperature`
 - `sensor.nordpool_kwh_nl_eur_0_10`
 - `sensor.forecast_solar_energy_production_today`
+- `sensor.hourly_heat_loss`
+- `sensor.hourly_solar_gain`
+- `sensor.hourly_net_heat_demand`
 
 Gebruik een kaarttype zoals **entities**, **sensor graph**, of **custom:apexcharts-card** om toekomstige waarden te tonen.
 

--- a/custom_components/optimizer/const.py
+++ b/custom_components/optimizer/const.py
@@ -22,6 +22,23 @@ CONF_POWER_CONSUMPTION = "power_consumption"
 # Allowed energy labels
 ENERGY_LABELS = ["A", "B", "C", "D", "E", "F", "G"]
 
+# Mapping energielabel -> U-waarde (W/m²K)
+U_VALUE_MAP = {
+    "A": 0.6,
+    "B": 0.8,
+    "C": 1.0,
+    "D": 1.2,
+    "E": 1.4,
+    "F": 1.6,
+    "G": 1.8,
+}
+
+# Binnentemperatuur in °C voor warmteverliesberekening
+INDOOR_TEMPERATURE = 21.0
+
+# Efficiëntiefactor voor zoninstraling
+SOLAR_EFFICIENCY = 0.15
+
 # Possible source types
 SOURCE_TYPE_CONSUMPTION = "Electricity consumption"
 SOURCE_TYPE_PRODUCTION = "Electricity production"


### PR DESCRIPTION
## Summary
- add mapping from energy label to U-value
- support solar efficiency and indoor temperature constants
- add sensors for heat loss, solar gain and net heat demand
- document new sensors in README

## Testing
- `pre-commit run --files custom_components/optimizer/const.py custom_components/optimizer/sensor.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_6882108315448323a675db01f3c17ce9