### PR TITLE
Fix sensor names not set

### DIFF
--- a/custom_components/optimizer/sensor.py
+++ b/custom_components/optimizer/sensor.py
@@ -46,7 +46,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
     ):
         unit = "€/kWh"
         super().__init__(
-            name=None,
+            name=name,
             unique_id=unique_id,
             unit=unit,
             device_class=None,
@@ -110,7 +110,7 @@ class HeatLossSensor(BaseUtilitySensor):
         device: DeviceInfo,
     ):
         super().__init__(
-            name=None,
+            name=name,
             unique_id=unique_id,
             unit="kW",
             device_class=None,
@@ -174,7 +174,7 @@ class SolarGainSensor(BaseUtilitySensor):
         device: DeviceInfo,
     ):
         super().__init__(
-            name=None,
+            name=name,
             unique_id=unique_id,
             unit="kW",
             device_class=None,
@@ -238,7 +238,7 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         device: DeviceInfo,
     ):
         super().__init__(
-            name=None,
+            name=name,
             unique_id=unique_id,
             unit="kW",
             device_class=None,


### PR DESCRIPTION
## Summary
- fix sensors returning `None` for names by using provided name strings

## Testing
- `pre-commit run --files custom_components/optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_68821d23a43c832381dd4012f5fb63b0