### PR TITLE
Add window solar gain sensor using Open-Meteo

### DIFF
--- a/custom_components/optimizer/const.py
+++ b/custom_components/optimizer/const.py
@@ -15,9 +15,11 @@ CONF_PRICE_SETTINGS = "price_settings"
 # New configuration keys for the heatpump optimizer
 CONF_AREA_M2 = "area_m2"
 CONF_ENERGY_LABEL = "energy_label"
-CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
-# Optional weather entity providing a temperature forecast array
-CONF_OUTDOOR_FORECAST = "outdoor_forecast"
+# Glass related configuration
+CONF_GLASS_EAST_M2 = "glass_east_m2"
+CONF_GLASS_WEST_M2 = "glass_west_m2"
+CONF_GLASS_SOUTH_M2 = "glass_south_m2"
+CONF_GLASS_U_VALUE = "glass_u_value"
 # One or more Solcast sensors. The sensors should expose a ``detailed forecast``
 # attribute with the expected PV production for the coming hours. The raw list
 # from these attributes will be copied to the solar gain sensor attributes.

--- a/custom_components/optimizer/manifest.json
+++ b/custom_components/optimizer/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/bvweerd/dynamic_energy_contract_calculator/issues",
   "quality_scale": "silver",
-  "requirements": [],
+  "requirements": ["aiohttp"],
   "ssdp": [],
   "version": "0.0.1",
   "zeroconf": []

--- a/custom_components/optimizer/sensor.py
+++ b/custom_components/optimizer/sensor.py
@@ -5,6 +5,8 @@ from homeassistant.components.sensor import SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
+import aiohttp
+import math
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -16,8 +18,10 @@ from .const import (
     SOURCE_TYPE_PRODUCTION,
     CONF_AREA_M2,
     CONF_ENERGY_LABEL,
-    CONF_OUTDOOR_TEMPERATURE,
-    CONF_OUTDOOR_FORECAST,
+    CONF_GLASS_EAST_M2,
+    CONF_GLASS_WEST_M2,
+    CONF_GLASS_SOUTH_M2,
+    CONF_GLASS_U_VALUE,
     CONF_SOLAR_FORECAST,
     U_VALUE_MAP,
     INDOOR_TEMPERATURE,
@@ -80,6 +84,10 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
+        await self.session.close()
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass,
@@ -104,8 +112,6 @@ class HeatLossSensor(BaseUtilitySensor):
         hass: HomeAssistant,
         name: str,
         unique_id: str,
-        outdoor_sensor: str,
-        forecast_sensor: str | None,
         area_m2: float,
         energy_label: str,
         icon: str,
@@ -123,77 +129,46 @@ class HeatLossSensor(BaseUtilitySensor):
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
-        self.outdoor_sensor = outdoor_sensor
-        self.forecast_sensor = forecast_sensor
         self._extra_attrs: dict[str, list[float]] = {}
         self.area_m2 = area_m2
         self.energy_label = energy_label
+        self.latitude = hass.config.latitude
+        self.longitude = hass.config.longitude
+        self.session = aiohttp.ClientSession()
 
-    def _extract_forecast(self, state) -> list[float]:
-        data = state.attributes.get("forecast") or []
-        temps: list[float] = []
-        if isinstance(data, (list, tuple)):
-            for item in data:
-                val = item.get("temperature") if isinstance(item, dict) else item
-                if val is None:
-                    val = item.get("temp") if isinstance(item, dict) else None
-                try:
-                    temps.append(float(val))
-                except (TypeError, ValueError):
-                    continue
-        return temps
+    async def _fetch_weather(self) -> tuple[float, list[float]]:
+        url = (
+            "https://api.open-meteo.com/v1/forecast"
+            f"?latitude={self.latitude}&longitude={self.longitude}"
+            "&hourly=temperature_2m&current_weather=true&timezone=UTC"
+        )
+        async with self.session.get(url) as resp:
+            data = await resp.json()
+        current = float(data.get("current_weather", {}).get("temperature", 0))
+        temps = [float(t) for t in data.get("hourly", {}).get("temperature_2m", [])]
+        return current, temps
 
     @property
     def extra_state_attributes(self) -> dict[str, list[float]]:
         return self._extra_attrs
 
-    def _compute_value(self) -> None:
-        state = self.hass.states.get(self.outdoor_sensor)
-        if state is None or state.state in ("unknown", "unavailable"):
-            self._attr_available = False
-            _LOGGER.warning(
-                "Outdoor temperature sensor %s is unavailable", self.outdoor_sensor
-            )
-            return
-        try:
-            t_outdoor = float(state.state)
-        except ValueError:
-            self._attr_available = False
-            _LOGGER.warning(
-                "Outdoor temperature sensor %s has invalid state", self.outdoor_sensor
-            )
-            return
+    async def _compute_value(self) -> None:
+        current, forecast = await self._fetch_weather()
         self._attr_available = True
         u_value = U_VALUE_MAP.get(self.energy_label.upper(), 1.0)
-        q_loss = self.area_m2 * u_value * (INDOOR_TEMPERATURE - t_outdoor) / 1000.0
+        q_loss = self.area_m2 * u_value * (INDOOR_TEMPERATURE - current) / 1000.0
         self._attr_native_value = round(q_loss, 3)
-
-        if self.forecast_sensor:
-            forecast_state = self.hass.states.get(self.forecast_sensor)
-            forecast_values: list[float] = []
-            if forecast_state:
-                temps = self._extract_forecast(forecast_state)
-                for temp in temps:
-                    qf = self.area_m2 * u_value * (INDOOR_TEMPERATURE - temp) / 1000.0
-                    forecast_values.append(round(qf, 3))
-            self._extra_attrs = {"forecast": forecast_values}
-        else:
-            self._extra_attrs = {}
+        forecast_values = [
+            round(self.area_m2 * u_value * (INDOOR_TEMPERATURE - t) / 1000.0, 3)
+            for t in forecast
+        ]
+        self._extra_attrs = {"forecast": forecast_values}
 
     async def async_update(self):
-        self._compute_value()
+        await self._compute_value()
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self.outdoor_sensor, self._handle_change
-            )
-        )
-
-    async def _handle_change(self, event):
-        self._compute_value()
-        self.async_write_ha_state()
 
 
 class SolarGainSensor(BaseUtilitySensor):
@@ -260,7 +235,7 @@ class SolarGainSensor(BaseUtilitySensor):
     def extra_state_attributes(self) -> dict[str, list[float]]:
         return self._extra_attrs
 
-    def _compute_value(self) -> None:
+    async def _compute_value(self) -> None:
         total_solar = 0.0
         attr_data: dict[str, list[float]] = {}
         cumulative: list[float] = []
@@ -312,9 +287,99 @@ class SolarGainSensor(BaseUtilitySensor):
                 async_track_state_change_event(self.hass, sensor, self._handle_change)
             )
 
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
+        await self.session.close()
+
     async def _handle_change(self, event):
         self._compute_value()
         self.async_write_ha_state()
+
+
+class WindowSolarGainSensor(BaseUtilitySensor):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        name: str,
+        unique_id: str,
+        east_m2: float,
+        west_m2: float,
+        south_m2: float,
+        u_value: float,
+        icon: str,
+        device: DeviceInfo,
+    ):
+        super().__init__(
+            name=name,
+            unique_id=unique_id,
+            unit="kW",
+            device_class=None,
+            icon=icon,
+            visible=True,
+            device=device,
+            translation_key=name.lower().replace(" ", "_"),
+        )
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self.hass = hass
+        self.east = east_m2
+        self.west = west_m2
+        self.south = south_m2
+        self.u_value = u_value
+        self.latitude = hass.config.latitude
+        self.longitude = hass.config.longitude
+        self.session = aiohttp.ClientSession()
+        self._extra_attrs: dict[str, list[float]] = {}
+
+    async def _fetch_radiation(self) -> list[float]:
+        url = (
+            "https://api.open-meteo.com/v1/forecast"
+            f"?latitude={self.latitude}&longitude={self.longitude}"
+            "&hourly=shortwave_radiation&timezone=UTC"
+        )
+        async with self.session.get(url) as resp:
+            data = await resp.json()
+        return [float(v) for v in data.get("hourly", {}).get("shortwave_radiation", [])]
+
+    def _orientation_factor(self, azimuth: float, orientation: float) -> float:
+        diff = abs(azimuth - orientation)
+        if diff > 180:
+            diff = 360 - diff
+        return max(math.cos(math.radians(diff)), 0)
+
+    async def _compute_value(self) -> None:
+        rad = await self._fetch_radiation()
+        sun = self.hass.states.get("sun.sun")
+        az = float(sun.attributes.get("azimuth", 0)) if sun else 0.0
+        elev = float(sun.attributes.get("elevation", 0)) if sun else 0.0
+        fac = max(math.sin(math.radians(elev)), 0)
+        total_area = self.east + self.west + self.south
+        orient_factors = (
+            self._orientation_factor(az, 90) * self.east
+            + self._orientation_factor(az, 270) * self.west
+            + self._orientation_factor(az, 180) * self.south
+        ) / (total_area or 1)
+        if rad:
+            current = rad[0] * fac * orient_factors * total_area / self.u_value / 1000.0
+            forecast = [
+                round(v * fac * orient_factors * total_area / self.u_value / 1000.0, 3)
+                for v in rad
+            ]
+        else:
+            current = 0.0
+            forecast = []
+        self._attr_available = True
+        self._attr_native_value = round(current, 3)
+        self._extra_attrs = {"forecast": forecast}
+
+    async def async_update(self):
+        await self._compute_value()
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
+        await self.session.close()
 
 
 class NetHeatDemandSensor(BaseUtilitySensor):
@@ -323,7 +388,6 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         hass: HomeAssistant,
         name: str,
         unique_id: str,
-        outdoor_sensor: str,
         solar_sensor: list[str],
         area_m2: float,
         energy_label: str,
@@ -342,21 +406,22 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
-        self.outdoor_sensor = outdoor_sensor
         self.solar_sensors = solar_sensor
         self.area_m2 = area_m2
         self.energy_label = energy_label
+        self.latitude = hass.config.latitude
+        self.longitude = hass.config.longitude
+        self.session = aiohttp.ClientSession()
 
     def _compute_value(self) -> None:
-        outdoor_state = self.hass.states.get(self.outdoor_sensor)
-        if outdoor_state is None or outdoor_state.state in ("unknown", "unavailable"):
-            self._attr_available = False
-            return
-        try:
-            t_outdoor = float(outdoor_state.state)
-        except ValueError:
-            self._attr_available = False
-            return
+        url = (
+            "https://api.open-meteo.com/v1/forecast"
+            f"?latitude={self.latitude}&longitude={self.longitude}"
+            "&current_weather=true&hourly=temperature_2m&timezone=UTC"
+        )
+        async with self.session.get(url) as resp:
+            data = await resp.json()
+        t_outdoor = float(data.get("current_weather", {}).get("temperature", 0))
 
         solar_total = 0.0
         for sensor in self.solar_sensors:
@@ -376,23 +441,22 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         self._attr_native_value = round(q_net, 3)
 
     async def async_update(self):
-        self._compute_value()
+        await self._compute_value()
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self.outdoor_sensor, self._handle_change
-            )
-        )
         for sensor in self.solar_sensors:
             self.async_on_remove(
                 async_track_state_change_event(self.hass, sensor, self._handle_change)
             )
 
     async def _handle_change(self, event):
-        self._compute_value()
+        await self._compute_value()
         self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
+        await self.session.close()
 
 
 async def async_setup_entry(
@@ -409,11 +473,13 @@ async def async_setup_entry(
 
     area_m2 = entry.data.get(CONF_AREA_M2)
     energy_label = entry.data.get(CONF_ENERGY_LABEL)
-    outdoor_sensor = entry.data.get(CONF_OUTDOOR_TEMPERATURE)
-    outdoor_forecast = entry.data.get(CONF_OUTDOOR_FORECAST)
     solar_sensor = entry.data.get(CONF_SOLAR_FORECAST)
     if isinstance(solar_sensor, str):
         solar_sensor = [solar_sensor]
+    glass_east = float(entry.data.get(CONF_GLASS_EAST_M2, 0))
+    glass_west = float(entry.data.get(CONF_GLASS_WEST_M2, 0))
+    glass_south = float(entry.data.get(CONF_GLASS_SOUTH_M2, 0))
+    glass_u = float(entry.data.get(CONF_GLASS_U_VALUE, 1.2))
 
     price_sensor = entry.data.get(CONF_PRICE_SENSOR)
     if price_sensor:
@@ -444,14 +510,12 @@ async def async_setup_entry(
 
         UTILITY_ENTITIES.extend(entities)
 
-    if outdoor_sensor and area_m2 and energy_label:
+    if area_m2 and energy_label:
         entities.append(
             HeatLossSensor(
                 hass=hass,
                 name="Hourly Heat Loss",
                 unique_id=f"{DOMAIN}_hourly_heat_loss",
-                outdoor_sensor=outdoor_sensor,
-                forecast_sensor=outdoor_forecast,
                 area_m2=float(area_m2),
                 energy_label=energy_label,
                 icon="mdi:home-thermometer",
@@ -472,13 +536,27 @@ async def async_setup_entry(
             )
         )
 
-    if outdoor_sensor and solar_sensor and area_m2 and energy_label:
+    if area_m2 and (glass_east or glass_west or glass_south):
+        entities.append(
+            WindowSolarGainSensor(
+                hass=hass,
+                name="Window Solar Gain",
+                unique_id=f"{DOMAIN}_window_solar_gain",
+                east_m2=glass_east,
+                west_m2=glass_west,
+                south_m2=glass_south,
+                u_value=glass_u,
+                icon="mdi:window-closed-variant",
+                device=device_info,
+            )
+        )
+
+    if solar_sensor and area_m2 and energy_label:
         entities.append(
             NetHeatDemandSensor(
                 hass=hass,
                 name="Hourly Net Heat Demand",
                 unique_id=f"{DOMAIN}_hourly_net_heat_demand",
-                outdoor_sensor=outdoor_sensor,
                 solar_sensor=solar_sensor,
                 area_m2=float(area_m2),
                 energy_label=energy_label,


### PR DESCRIPTION
## Summary
- add window area and u-value options
- switch heat loss sensor to Open-Meteo
- create new window solar gain sensor
- update manifest requirements

## Testing
- `pre-commit run --files custom_components/optimizer/const.py custom_components/optimizer/config_flow.py custom_components/optimizer/sensor.py custom_components/optimizer/manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_68826a357d7483239163b9df3e3d7394