### PR TITLE
Fix missing forecast attribute

### DIFF
--- a/custom_components/optimizer/sensor.py
+++ b/custom_components/optimizer/sensor.py
@@ -409,6 +409,10 @@ class WindowSolarGainSensor(BaseUtilitySensor):
             diff = 360 - diff
         return max(math.cos(math.radians(diff)), 0)
 
+    @property
+    def extra_state_attributes(self) -> dict[str, list[float]]:
+        return self._extra_attrs
+
     async def _compute_value(self) -> None:
         rad = await self._fetch_radiation()
         sun = self.hass.states.get("sun.sun")


### PR DESCRIPTION
## Summary
- expose `extra_state_attributes` for `WindowSolarGainSensor`

## Testing
- `pre-commit run --files custom_components/optimizer/sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688385bcb0488323a0ff0e9a2fa9cb2e