### PR TITLE
Fix EnergyConsumptionForecastSensor visibility when sensors added in options

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -696,7 +696,7 @@ async def async_setup_entry(
     )
     entities: list[BaseUtilitySensor] = []
 
-    configs = entry.data.get(CONF_CONFIGS, [])
+    configs = entry.options.get(CONF_CONFIGS, entry.data.get(CONF_CONFIGS, []))
     consumption_sources: list[str] = []
     production_sources: list[str] = []
     for cfg in configs:


### PR DESCRIPTION
## Summary
- fix config retrieval to consider options

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_688390b4121c8323ba51e2989cf0ad91