### PR TITLE
Rename solar gain sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ heating_curve_optimizer:
 ### `sensor.hourly_heat_loss`
 - Berekend warmteverlies van de woning in kW
 
-### `sensor.hourly_solar_gain`
-- Verwachte zonnewinst in kW
+### `sensor.solar_panel_yield`
+- Verwachte opbrengst van zonnepanelen in kW
 
 ### `sensor.hourly_net_heat_demand`
 - Netto warmtevraag na aftrek van zonwinst in kW
@@ -179,7 +179,7 @@ Voeg de volgende sensoren toe aan je Lovelace-dashboard:
 - `sensor.nordpool_kwh_nl_eur_0_10`
 - `sensor.solcast_pv_forecast_forecast_today`
 - `sensor.hourly_heat_loss`
-- `sensor.hourly_solar_gain`
+- `sensor.solar_panel_yield`
 - `sensor.hourly_net_heat_demand`
 
 Gebruik een kaarttype zoals **entities**, **sensor graph**, of **custom:apexcharts-card** om toekomstige waarden te tonen.
@@ -218,15 +218,15 @@ gebruikt de oppervlakte van de woning en het energielabel om een U-waarde te
 bepalen. Deze U-waarde wordt vermenigvuldigd met het temperatuurverschil tussen
 binnen en buiten.
 
-### `sensor.hourly_solar_gain`
-De totale zonnewarmte die via zonnepanelen verwacht wordt. De integratie leest
-de `detailed forecast` van de opgegeven Solcast sensoren uit, telt de waarden op
-en past een efficiëntiefactor toe zodat de output in kilowatt wordt weergegeven.
+### `sensor.solar_panel_yield`
+De totale opbrengst van zonnepanelen die verwacht wordt. De integratie leest de
+`detailed forecast` van de opgegeven Solcast sensoren uit, telt de waarden op en
+past een efficiëntiefactor toe zodat de output in kilowatt wordt weergegeven.
 
 ### `sensor.hourly_net_heat_demand`
 Dit is het verschil tussen het warmteverlies en de zonnewinst. Negatieve waarden
 worden op nul gezet. Deze sensor gebruikt direct de opgegeven Solcast sensoren
-en **niet** `sensor.hourly_solar_gain`. Zo zie je hoeveel netto warmte er per uur
+en **niet** `sensor.solar_panel_yield`. Zo zie je hoeveel netto warmte er per uur
 nodig is om de binnentemperatuur op peil te houden.
 
 

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -22,7 +22,7 @@ CONF_GLASS_SOUTH_M2 = "glass_south_m2"
 CONF_GLASS_U_VALUE = "glass_u_value"
 # One or more Solcast sensors. The sensors should expose a ``detailed forecast``
 # attribute with the expected PV production for the coming hours. The raw list
-# from these attributes will be copied to the solar gain sensor attributes.
+# from these attributes will be copied to the solar panel yield sensor attributes.
 CONF_SOLAR_FORECAST = "solar_forecasts"
 CONF_POWER_CONSUMPTION = "power_consumption"
 CONF_INDOOR_TEMPERATURE_SENSOR = "indoor_temperature_sensor"

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -210,7 +210,7 @@ class HeatLossSensor(BaseUtilitySensor):
         await super().async_added_to_hass()
 
 
-class SolarGainSensor(BaseUtilitySensor):
+class SolarPanelYieldSensor(BaseUtilitySensor):
     def __init__(
         self,
         hass: HomeAssistant,
@@ -274,7 +274,8 @@ class SolarGainSensor(BaseUtilitySensor):
                         or item.get("watts")
                     )
                     ts = (
-                        item.get("period_end")
+                        item.get("period_start")
+                        or item.get("period_end")
                         or item.get("period")
                         or item.get("time")
                         or item.get("dt")
@@ -761,10 +762,10 @@ async def async_setup_entry(
 
     if solar_sensor and area_m2:
         entities.append(
-            SolarGainSensor(
+            SolarPanelYieldSensor(
                 hass=hass,
-                name="Hourly Solar Gain",
-                unique_id=f"{DOMAIN}_hourly_solar_gain",
+                name="Solar Panel Yield",
+                unique_id=f"{DOMAIN}_solar_panel_yield",
                 solar_sensor=solar_sensor,
                 area_m2=float(area_m2),
                 icon="mdi:weather-sunny",


### PR DESCRIPTION
## Summary
- rename `SolarGainSensor` to `SolarPanelYieldSensor`
- support `period_start` timestamps
- update docs for new `sensor.solar_panel_yield`

## Testing
- `pre-commit run --files README.md custom_components/heating_curve_optimizer/const.py custom_components/heating_curve_optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_688393ceae148323baecae26f0c9fff2