### PR TITLE
Add outdoor temperature and COP sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ heating_curve_optimizer:
 | `solar_forecast`     | Solcast (1 of meer) | Totale dagopbrengst → verdeeld over forecast-horizon |
 | `price_forecast`     | Nordpool                   | Prijs per uur over horizon                           |
 | `power_consumption`  | DSMR of vermogenssensor    | Actuele warmtepompverbruik (optioneel)              |
+| `supply_temperature` | sensor                     | Aanvoertemperatuur warmtepomp                       |
+| `k_factor`           | UI-config                  | Correctiefactor voor COP-berekening                 |
 | `indoor_temperature` | sensor                     | Actuele binnentemperatuur                            |
 
 ---
@@ -99,6 +101,12 @@ heating_curve_optimizer:
 
 ### `sensor.current_net_consumption`
 - Actuele netto stroomafname (verbruik min productie) in kW
+
+### `sensor.outdoor_temperature`
+- Buitentemperatuur met een 24-uurs voorspelling
+
+### `sensor.heat_pump_cop`
+- Actuele COP berekend met k-factor
 
 ---
 

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -25,6 +25,8 @@ CONF_GLASS_U_VALUE = "glass_u_value"
 CONF_SOLAR_FORECAST = "solar_forecasts"
 CONF_POWER_CONSUMPTION = "power_consumption"
 CONF_INDOOR_TEMPERATURE_SENSOR = "indoor_temperature_sensor"
+CONF_SUPPLY_TEMPERATURE_SENSOR = "supply_temperature_sensor"
+CONF_K_FACTOR = "k_factor"
 
 # Allowed energy labels
 ENERGY_LABELS = ["A", "B", "C", "D", "E", "F", "G"]


### PR DESCRIPTION
## Summary
- add outdoor temperature sensor with 24h forecast
- add quadratic COP sensor using k-factor
- support supply temperature and k factor in config flow
- document new configuration and sensors

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/const.py custom_components/heating_curve_optimizer/config_flow.py custom_components/heating_curve_optimizer/sensor.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b5e853a48323afdcdfba727b2160