### PR TITLE
Update COP model with linear k-factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,14 @@ Q_{netto} = Q_{verlies} - Q_{zon}
 1. **Fallback-model** (als geen werkelijk verbruik beschikbaar):
 
 \[
-COP = 6 - 0.1 \cdot (T_{aanvoer} - T_{buiten})
+COP(T_a) = a - k \cdot (T_a - 35)
 \]
+
+waarbij:
+
+- \(a\): gemeten COP bij \(T_a=35\,\degree C\) (typisch 4–4,5)
+- \(k\): afname in COP per graad (ongeveer 0,10–0,12)
+- \(T_a\): gewenste aanvoertemperatuur in \(^\circ C\)
 
 2. **Werkelijk** (als warmtepompvermogen bekend):
 

--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_K_FACTOR,
     CONF_PRICE_SENSOR,
     CONF_PRICE_SETTINGS,
+    DEFAULT_K_FACTOR,
     CONF_SOLAR_FORECAST,
     CONF_SOURCE_TYPE,
     CONF_SOURCES,
@@ -185,7 +186,7 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.supply_temperature_sensor = user_input.get(
                 CONF_SUPPLY_TEMPERATURE_SENSOR
             )
-            self.k_factor = float(user_input.get(CONF_K_FACTOR, 1.0))
+            self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
             return await self.async_step_user()
 
         energy_sensors = await self._get_energy_sensors()
@@ -247,9 +248,9 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         }
                     }
                 ),
-                vol.Optional(CONF_K_FACTOR, default=self.k_factor or 3.5): vol.Coerce(
-                    float
-                ),
+                vol.Optional(
+                    CONF_K_FACTOR, default=self.k_factor or DEFAULT_K_FACTOR
+                ): vol.Coerce(float),
             }
         )
 
@@ -274,7 +275,7 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.supply_temperature_sensor = user_input.get(
                 CONF_SUPPLY_TEMPERATURE_SENSOR
             )
-            self.k_factor = float(user_input.get(CONF_K_FACTOR, 1.0))
+            self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
             return await self.async_step_user()
 
         energy_sensors = await self._get_energy_sensors()
@@ -336,9 +337,9 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         }
                     }
                 ),
-                vol.Optional(CONF_K_FACTOR, default=self.k_factor or 3.5): vol.Coerce(
-                    float
-                ),
+                vol.Optional(
+                    CONF_K_FACTOR, default=self.k_factor or DEFAULT_K_FACTOR
+                ): vol.Coerce(float),
             }
         )
 

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -48,6 +48,12 @@ INDOOR_TEMPERATURE = 21.0
 # Efficiëntiefactor voor zoninstraling
 SOLAR_EFFICIENCY = 0.15
 
+# Default COP at a supply temperature of 35 °C
+DEFAULT_COP_AT_35 = 4.2
+
+# Default decline in COP per °C supply temperature increase
+DEFAULT_K_FACTOR = 0.11
+
 # Possible source types
 SOURCE_TYPE_CONSUMPTION = "Electricity consumption"
 SOURCE_TYPE_PRODUCTION = "Electricity production"

--- a/reference_material/stooklijn_mip_optimalisatie.py
+++ b/reference_material/stooklijn_mip_optimalisatie.py
@@ -1,8 +1,7 @@
 # MIP-based stooklijn optimalisatie met dummydata
 # Run dit script met Python 3 + pulp geïnstalleerd
 
-from pulp import *
-import numpy as np
+from pulp import LpMinimize, LpProblem, LpVariable, lpSum, value
 
 # === Data ===
 T_out = [5, 4, 3, 2]  # Buitentemperatuur
@@ -20,15 +19,15 @@ Q_loss = [Area * U * (T_in - T_out[t]) / 1000 for t in range(H)]
 Q_solar = [Solar[t] * Area * eta_solar / 1000 for t in range(H)]
 Q_netto = [max(0, Q_loss[t] - Q_solar[t]) for t in range(H)]
 
-model = LpProblem('StooklijnOptimalisatie', LpMinimize)
-offsets = LpVariable.dicts('offset', range(H), -4, 4, cat='Integer')
-deltas = LpVariable.dicts('delta', range(1, H), 0, 8, cat='Integer')
+model = LpProblem("StooklijnOptimalisatie", LpMinimize)
+offsets = LpVariable.dicts("offset", range(H), -4, 4, cat="Integer")
+deltas = LpVariable.dicts("delta", range(1, H), 0, 8, cat="Integer")
 
 costs = []
 for t in range(H):
     t_supply = base_supply_temp + offsets[t]
-    delta_t = t_supply - T_out[t]
-    cop = 6 - 0.1 * delta_t
+    delta_t = t_supply - 35
+    cop = 4.2 - 0.11 * delta_t
     q = Q_netto[t]
     costs.append((q / cop) * Price[t])
 
@@ -40,8 +39,8 @@ for t in range(H):
     model += (base_supply_temp + offsets[t]) <= 45
 
 for t in range(1, H):
-    model += offsets[t] - offsets[t-1] <= deltas[t]
-    model += offsets[t-1] - offsets[t] <= deltas[t]
+    model += offsets[t] - offsets[t - 1] <= deltas[t]
+    model += offsets[t - 1] - offsets[t] <= deltas[t]
     model += deltas[t] <= 1
 
 model.solve()
@@ -49,5 +48,5 @@ model.solve()
 optimal_offsets = [int(value(offsets[t])) for t in range(H)]
 total_cost = value(model.objective)
 
-print('Optimal Offsets per hour:', optimal_offsets)
-print('Total Expected Cost (€): {:.4f}'.format(total_cost))
+print("Optimal Offsets per hour:", optimal_offsets)
+print(f"Total Expected Cost (€): {total_cost:.4f}")


### PR DESCRIPTION
## Summary
- implement k‑factor formula for COP calculation
- expose new `DEFAULT_COP_AT_35` and `DEFAULT_K_FACTOR` constants
- use k‑factor defaults in config flow
- document the linear COP formula
- update optimisation example script

## Testing
- `pre-commit run --files README.md custom_components/heating_curve_optimizer/config_flow.py custom_components/heating_curve_optimizer/const.py custom_components/heating_curve_optimizer/sensor.py reference_material/stooklijn_mip_optimalisatie.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bc2e1bc48323b703a33a6d781368