### PR TITLE
Allow negative net heat demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,7 @@ bepalen. Deze U-waarde wordt vermenigvuldigd met het temperatuurverschil tussen
 binnen en buiten.
 
 ### `sensor.hourly_net_heat_demand`
-Dit is het verschil tussen het warmteverlies en de zonnewinst. Negatieve waarden
-worden op nul gezet. Deze sensor gebruikt direct de opgegeven Solcast sensoren.
+Dit is het verschil tussen het warmteverlies en de zonnewinst. De waarde kan dus ook negatief zijn wanneer de zonnewinst groter is dan het verlies. Deze sensor gebruikt direct de opgegeven Solcast sensoren.
 Zo zie je hoeveel netto warmte er per uur nodig is om de binnentemperatuur op peil te houden.
 
 

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -499,7 +499,7 @@ class NetHeatDemandSensor(BaseUtilitySensor):
                     indoor = INDOOR_TEMPERATURE
         q_loss = self.area_m2 * u_value * (indoor - t_outdoor) / 1000.0
         q_solar = solar_total * self.area_m2 * SOLAR_EFFICIENCY / 1000.0
-        q_net = max(q_loss - q_solar, 0.0)
+        q_net = q_loss - q_solar
         self._attr_native_value = round(q_net, 3)
 
         loss_fc = []
@@ -514,7 +514,7 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         for i in range(n):
             lf = loss_fc[i] if i < len(loss_fc) else 0.0
             gf = gain_fc[i] if i < len(gain_fc) else 0.0
-            forecast.append(round(max(lf - gf, 0.0), 3))
+            forecast.append(round(lf - gf, 3))
 
         self._extra_attrs = {"forecast": forecast}
 


### PR DESCRIPTION
## Summary
- allow negative net heat demand in `NetHeatDemandSensor`
- document the possibility of negative values

## Testing
- `pre-commit run --files README.md custom_components/heating_curve_optimizer/sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ec5f4aa883239f9cb89be974a520