### PR TITLE
Add heating curve optimization sensor

### DIFF
--- a/custom_components/heating_curve_optimizer/manifest.json
+++ b/custom_components/heating_curve_optimizer/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/bvweerd/heating_curve_optimizer/issues",
   "quality_scale": "silver",
-  "requirements": ["aiohttp"],
+  "requirements": ["aiohttp", "pulp"],
   "ssdp": [],
   "version": "0.0.1",
   "zeroconf": []


### PR DESCRIPTION
## Summary
- add `pulp` to manifest requirements
- implement `HeatingCurveOffsetSensor` that computes optimal offsets for the next six hours
- generate offsets using PuLP MILP optimisation and expose forecast attribute
- include new sensor in setup

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/manifest.json custom_components/heating_curve_optimizer/sensor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_688507b84ff08323a901f5efc605e1b5