### PR TITLE
Fix db executor usage

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -843,17 +843,18 @@ class EnergyConsumptionForecastSensor(BaseUtilitySensor):
 
     async def _fetch_history(self, sensors: list[str], start, end) -> dict[str, list]:
         """Fetch history data for the given sensors."""  # mypy: ignore-errors
-        from homeassistant.components.recorder import history
+        from homeassistant.components.recorder import history, get_instance
 
         if not sensors:
             return {}
 
         func = cast(Any, history.get_significant_states)
+        recorder = get_instance(self.hass)
 
         try:
             return cast(
                 dict[str, list],
-                await self.hass.async_add_executor_job(
+                await recorder.async_add_executor_job(
                     func,
                     self.hass,
                     start,
@@ -870,7 +871,7 @@ class EnergyConsumptionForecastSensor(BaseUtilitySensor):
             for sensor in sensors:
                 data = cast(
                     dict[str, list],
-                    await self.hass.async_add_executor_job(
+                    await recorder.async_add_executor_job(
                         func,
                         self.hass,
                         start,

--- a/tests/test_energy_consumption_forecast_sensor.py
+++ b/tests/test_energy_consumption_forecast_sensor.py
@@ -25,11 +25,14 @@ async def test_fetch_history_multiple_entities(hass):
     with patch(
         "homeassistant.components.recorder.history.get_significant_states",
         return_value={},
-    ) as mock_get, patch.object(
-        hass,
-        "async_add_executor_job",
-        AsyncMock(side_effect=lambda func, *args: func(*args)),
-    ) as mock_exec:
+    ) as mock_get, patch(
+        "homeassistant.components.recorder.get_instance",
+    ) as mock_get_instance:
+        mock_recorder = AsyncMock()
+        mock_recorder.async_add_executor_job.side_effect = (
+            lambda func, *args: func(*args)
+        )
+        mock_get_instance.return_value = mock_recorder
         data = await sensor._fetch_history(["sensor.c1", "sensor.c2"], start, end)
 
     mock_get.assert_called_once()


### PR DESCRIPTION
## Summary
- use recorder executor for history calls
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850b67cef08323a923e42e468fb63d