### PR TITLE
Fix outdoor temperature sensor state class

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -64,6 +64,7 @@ class OutdoorTemperatureSensor(BaseUtilitySensor):
             device=device,
             translation_key=name.lower().replace(" ", "_"),
         )
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
         self.latitude = hass.config.latitude
         self.longitude = hass.config.longitude

--- a/tests/test_outdoor_temperature_sensor.py
+++ b/tests/test_outdoor_temperature_sensor.py
@@ -1,0 +1,17 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.components.sensor import SensorStateClass
+
+from custom_components.heating_curve_optimizer.sensor import OutdoorTemperatureSensor
+
+@pytest.mark.asyncio
+async def test_outdoor_temperature_sensor_has_measurement_state_class(hass):
+    sensor = OutdoorTemperatureSensor(
+        hass=hass,
+        name="test",
+        unique_id="test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    await sensor.async_will_remove_from_hass()
+


### PR DESCRIPTION
## Summary
- make OutdoorTemperatureSensor use measurement state class
- add tests for OutdoorTemperatureSensor state class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850b8154848323a97632c53da530bd