### PR TITLE
Fix net_heat_sensor initialization

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -7,7 +7,7 @@ import math
 
 import aiohttp
 from pulp import LpMinimize, LpProblem, LpVariable, lpSum, value
-from homeassistant.components.sensor import SensorStateClass
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -700,7 +700,7 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
         hass: HomeAssistant,
         name: str,
         unique_id: str,
-        net_heat_sensor: str,
+        net_heat_sensor: str | SensorEntity,
         price_sensor: str,
         device: DeviceInfo,
         *,
@@ -768,8 +768,13 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
         return demand
 
     async def async_update(self):
-        net_state = self.hass.states.get(self.net_heat_sensor)
+        ent = (
+            self.net_heat_sensor.entity_id
+            if hasattr(self.net_heat_sensor, "entity_id")
+            else self.net_heat_sensor
+        )
         price_state = self.hass.states.get(self.price_sensor)
+        net_state = self.hass.states.get(ent) if ent else None
 
         if (
             net_state is None
@@ -799,10 +804,13 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
+        if not isinstance(self.net_heat_sensor, str):
+            self.net_heat_sensor = self.net_heat_sensor.entity_id
         for ent in (self.net_heat_sensor, self.price_sensor):
-            self.async_on_remove(
-                async_track_state_change_event(self.hass, ent, self._handle_change)
-            )
+            if ent:
+                self.async_on_remove(
+                    async_track_state_change_event(self.hass, ent, self._handle_change)
+                )
 
     async def _handle_change(self, event):
         await self.async_update()
@@ -1099,7 +1107,7 @@ async def async_setup_entry(
                 hass=hass,
                 name="Heating Curve Offset",
                 unique_id=f"{DOMAIN}_heating_curve_offset",
-                net_heat_sensor=net_heat_sensor.entity_id,
+                net_heat_sensor=net_heat_sensor,
                 price_sensor=price_sensor,
                 device=device_info,
                 k_factor=k_factor,

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -1,0 +1,37 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import (
+    HeatingCurveOffsetSensor,
+    NetHeatDemandSensor,
+)
+
+
+@pytest.mark.asyncio
+async def test_offset_sensor_handles_sensor_instance(hass):
+    net = NetHeatDemandSensor(
+        hass=hass,
+        name="Hourly Net Heat Demand",
+        unique_id="test_net",
+        area_m2=10.0,
+        energy_label="A",
+        indoor_sensor=None,
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+
+    hass.states.async_set("sensor.price", "0.0")
+
+    sensor = HeatingCurveOffsetSensor(
+        hass=hass,
+        name="Heating Curve Offset",
+        unique_id="offset",
+        net_heat_sensor=net,
+        price_sensor="sensor.price",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+
+    await sensor.async_update()
+    assert sensor.available is False
+    await sensor.async_will_remove_from_hass()
+    await net.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- prevent missing entity_id errors when initializing HeatingCurveOffsetSensor
- allow passing NetHeatDemandSensor instance to HeatingCurveOffsetSensor
- test initialization with sensor instance

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heating_curve_offset_sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d79dc2f48323ac921aa57c393782