### PR TITLE
Handle missing solver in optimizer

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -694,7 +694,11 @@ def _optimize_offsets(
         model += offsets[t - 1] - offsets[t] <= deltas[t]
         model += deltas[t] <= 1
 
-    model.solve()
+    try:
+        model.solve()
+    except FileNotFoundError as err:
+        _LOGGER.error("Optimization solver unavailable: %s", err)
+        return [0 for _ in range(horizon)]
     return [int(value(offsets[t])) for t in range(horizon)]
 
 


### PR DESCRIPTION
## Summary
- add missing CBC solver handling when solving LP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860446dba48323b9f8630ef24f550d