### PR TITLE
Add future_offsets attribute

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -680,17 +680,15 @@ def _optimize_offsets(
     dp: list[dict[int, tuple[float, int | None]]] = [{} for _ in range(horizon)]
 
     for off in allowed_offsets:
-        cost = demand[0] * prices[0] * (
-            reciprocal_base_cop + cop_derivative * off
-        )
+        cost = demand[0] * prices[0] * (reciprocal_base_cop + cop_derivative * off)
         dp[0][off] = (cost, None)
 
     for t in range(1, horizon):
         for off in allowed_offsets:
             best_cost = math.inf
             best_prev: int | None = None
-            step_cost = demand[t] * prices[t] * (
-                reciprocal_base_cop + cop_derivative * off
+            step_cost = (
+                demand[t] * prices[t] * (reciprocal_base_cop + cop_derivative * off)
             )
             for prev_off, (prev_cost, _) in dp[t - 1].items():
                 if abs(off - prev_off) <= 1:
@@ -825,7 +823,7 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
             self._attr_native_value = offsets[0]
         else:
             self._attr_native_value = 0
-        self._extra_attrs = {"forecast": offsets}
+        self._extra_attrs = {"future_offsets": offsets}
         self._attr_available = True
 
     async def async_added_to_hass(self):

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -6,6 +6,8 @@ from custom_components.heating_curve_optimizer.sensor import (
     NetHeatDemandSensor,
 )
 
+from unittest.mock import patch
+
 
 @pytest.mark.asyncio
 async def test_offset_sensor_handles_sensor_instance(hass):
@@ -35,3 +37,32 @@ async def test_offset_sensor_handles_sensor_instance(hass):
     assert sensor.available is False
     await sensor.async_will_remove_from_hass()
     await net.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_offset_sensor_sets_future_offsets_attribute(hass):
+    hass.states.async_set("sensor.net_heat", "1", {"forecast": [0.0] * 6})
+    hass.states.async_set(
+        "sensor.price",
+        "0.0",
+        {"raw_today": [0.0] * 24, "raw_tomorrow": []},
+    )
+
+    sensor = HeatingCurveOffsetSensor(
+        hass=hass,
+        name="Heating Curve Offset",
+        unique_id="offset2",
+        net_heat_sensor="sensor.net_heat",
+        price_sensor="sensor.price",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor._optimize_offsets",
+        return_value=[1, 2, 3, 4, 5, 6],
+    ):
+        await sensor.async_update()
+
+    assert sensor.native_value == 1
+    assert sensor.extra_state_attributes["future_offsets"] == [1, 2, 3, 4, 5, 6]
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- include future offsets on heating curve offset sensor
- test the new attribute on the offset sensor

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heating_curve_offset_sensor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68861eec5ce883238f104af2a9319d5c