### PR TITLE
Add prices attribute to offset sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ heating_curve_optimizer:
 - Huidige geadviseerde offset (bijv. +1.5 °C)
 - Attributes:
   - `future_offsets`: lijst met voorspelde offsets komende uren
+  - `prices`: gebruikte uurprijzen voor de berekening
   - `indoor_temperature_forecast`: voorspelde binnentemperatuur
   - (toekomstig) `predicted_savings`: verwachte energiekostenbesparing
 

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -823,7 +823,7 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
             self._attr_native_value = offsets[0]
         else:
             self._attr_native_value = 0
-        self._extra_attrs = {"future_offsets": offsets}
+        self._extra_attrs = {"future_offsets": offsets, "prices": prices}
         self._attr_available = True
 
     async def async_added_to_hass(self):

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -65,4 +65,5 @@ async def test_offset_sensor_sets_future_offsets_attribute(hass):
 
     assert sensor.native_value == 1
     assert sensor.extra_state_attributes["future_offsets"] == [1, 2, 3, 4, 5, 6]
+    assert sensor.extra_state_attributes["prices"] == [0.0] * 6
     await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- expose hourly price data on heating curve offset sensor
- document new attribute in README
- test that prices are included in extra attributes

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heating_curve_offset_sensor.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68862274ec688323ad10bcd326e93d62