### PR TITLE
Fix state class of heating curve offset sensor

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -852,6 +852,7 @@ class HeatingCurveOffsetSensor(BaseUtilitySensor):
             device=device,
             translation_key=name.lower().replace(" ", "_"),
         )
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
         self.net_heat_sensor = net_heat_sensor
         self.price_sensor = price_sensor

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -5,6 +5,7 @@ from custom_components.heating_curve_optimizer.sensor import (
     HeatingCurveOffsetSensor,
     NetHeatDemandSensor,
 )
+from homeassistant.components.sensor import SensorStateClass
 
 from unittest.mock import patch
 
@@ -66,4 +67,19 @@ async def test_offset_sensor_sets_future_offsets_attribute(hass):
     assert sensor.native_value == 1
     assert sensor.extra_state_attributes["future_offsets"] == [1, 2, 3, 4, 5, 6]
     assert sensor.extra_state_attributes["prices"] == [0.0] * 6
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_offset_sensor_has_measurement_state_class(hass):
+    sensor = HeatingCurveOffsetSensor(
+        hass=hass,
+        name="Heating Curve Offset",
+        unique_id="offset3",
+        net_heat_sensor="sensor.net_heat",
+        price_sensor="sensor.price",
+        device=DeviceInfo(identifiers={("test", "3")}),
+    )
+
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
     await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- set measurement state class for HeatingCurveOffsetSensor
- test that offset sensor uses measurement state class

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heating_curve_offset_sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871ad72cbc83238d55422c69cfba7e