### PR TITLE
Fix test formatting and run flake8

### DIFF
--- a/tests/test_outdoor_temperature_sensor.py
+++ b/tests/test_outdoor_temperature_sensor.py
@@ -4,6 +4,7 @@ from homeassistant.components.sensor import SensorStateClass
 
 from custom_components.heating_curve_optimizer.sensor import OutdoorTemperatureSensor
 
+
 @pytest.mark.asyncio
 async def test_outdoor_temperature_sensor_has_measurement_state_class(hass):
     sensor = OutdoorTemperatureSensor(
@@ -14,4 +15,3 @@ async def test_outdoor_temperature_sensor_has_measurement_state_class(hass):
     )
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     await sensor.async_will_remove_from_hass()
-


### PR DESCRIPTION
## Summary
- update spacing in `test_outdoor_temperature_sensor.py`
- remove trailing newline
- run flake8 to ensure no E302 or W391 errors

## Testing
- `flake8`
- `flake8 tests/test_outdoor_temperature_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_688725dc25988323bd21ea57ea95a611