### PR TITLE
Add sensor and config flow tests

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,63 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from custom_components.heating_curve_optimizer.const import DOMAIN, CONF_SOURCE_TYPE
+from custom_components.heating_curve_optimizer.config_flow import STEP_BASIC
+
+
+@pytest.mark.asyncio
+async def test_show_user_form(hass: HomeAssistant):
+    with patch("homeassistant.config_entries._load_integration", return_value=None):
+        with patch(
+            "homeassistant.loader.async_get_integration",
+            AsyncMock(
+                return_value=SimpleNamespace(domain=DOMAIN, single_config_entry=False)
+            ),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": "user"}
+            )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_abort_if_configured(hass: HomeAssistant):
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.config_entries._load_integration", return_value=None
+    ), patch(
+        "homeassistant.loader.async_get_integration",
+        AsyncMock(
+            return_value=SimpleNamespace(domain=DOMAIN, single_config_entry=False)
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.asyncio
+async def test_basic_options_step(hass: HomeAssistant):
+    with patch(
+        "homeassistant.config_entries._load_integration", return_value=None
+    ), patch(
+        "homeassistant.loader.async_get_integration",
+        AsyncMock(
+            return_value=SimpleNamespace(domain=DOMAIN, single_config_entry=False)
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_SOURCE_TYPE: STEP_BASIC}
+        )
+    assert result2["type"] == "form"
+    assert result2["step_id"] == STEP_BASIC

--- a/tests/test_current_electricity_price_sensor.py
+++ b/tests/test_current_electricity_price_sensor.py
@@ -1,0 +1,60 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.components.sensor import SensorStateClass
+
+from custom_components.heating_curve_optimizer.sensor import (
+    CurrentElectricityPriceSensor,
+)
+
+
+@pytest.mark.asyncio
+async def test_price_sensor_updates_value(hass):
+    hass.states.async_set("sensor.price", "0.123")
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price1",
+        price_sensor="sensor.price",
+        source_type="Electricity consumption",
+        price_settings={},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 0.123
+    assert sensor.available is True
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_price_sensor_unavailable_state(hass):
+    hass.states.async_set("sensor.price", "unavailable")
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price2",
+        price_sensor="sensor.price",
+        source_type="Electricity consumption",
+        price_settings={},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+    await sensor.async_update()
+    assert sensor.available is False
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_price_sensor_has_measurement_state_class(hass):
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price3",
+        price_sensor="sensor.price",
+        source_type="Electricity consumption",
+        price_settings={},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "3")}),
+    )
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_heat_loss_sensor.py
+++ b/tests/test_heat_loss_sensor.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import HeatLossSensor
+
+
+@pytest.mark.asyncio
+async def test_heat_loss_sensor_fetches_weather_when_no_outdoor(hass):
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = HeatLossSensor(
+            hass=hass,
+            name="Heat Loss",
+            unique_id="hl1",
+            area_m2=20.0,
+            energy_label="A",
+            indoor_sensor=None,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "1")}),
+        )
+    with patch.object(
+        sensor, "_fetch_weather", AsyncMock(return_value=(10.0, [11.0, 12.0]))
+    ):
+        await sensor.async_update()
+    assert sensor.native_value == 0.132
+    assert sensor.extra_state_attributes["forecast"] == [0.12, 0.108]
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_heat_loss_sensor_uses_outdoor_sensor_when_available(hass):
+    hass.states.async_set("sensor.outdoor", "5")
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = HeatLossSensor(
+            hass=hass,
+            name="Heat Loss",
+            unique_id="hl2",
+            area_m2=10.0,
+            energy_label="A",
+            indoor_sensor=None,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "2")}),
+            outdoor_sensor="sensor.outdoor",
+        )
+    with patch.object(sensor, "_fetch_weather", AsyncMock()) as mock_fetch:
+        await sensor.async_update()
+    mock_fetch.assert_not_called()
+    assert sensor.native_value == 0.096
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_heat_pump_thermal_power_sensor.py
+++ b/tests/test_heat_pump_thermal_power_sensor.py
@@ -1,0 +1,43 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import HeatPumpThermalPowerSensor
+
+
+@pytest.mark.asyncio
+async def test_heat_pump_thermal_power_sensor_computes_value(hass):
+    hass.states.async_set("sensor.power", "1000")
+    hass.states.async_set("sensor.supply", "35")
+    hass.states.async_set("sensor.outdoor", "5")
+    sensor = HeatPumpThermalPowerSensor(
+        hass=hass,
+        name="Thermal Power",
+        unique_id="tp1",
+        power_sensor="sensor.power",
+        supply_sensor="sensor.supply",
+        outdoor_sensor="sensor.outdoor",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == pytest.approx(4.2, rel=1e-3)
+    assert sensor.available is True
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_heat_pump_thermal_power_sensor_handles_unavailable(hass):
+    hass.states.async_set("sensor.power", "unavailable")
+    hass.states.async_set("sensor.supply", "35")
+    hass.states.async_set("sensor.outdoor", "5")
+    sensor = HeatPumpThermalPowerSensor(
+        hass=hass,
+        name="Thermal Power",
+        unique_id="tp2",
+        power_sensor="sensor.power",
+        supply_sensor="sensor.supply",
+        outdoor_sensor="sensor.outdoor",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+    await sensor.async_update()
+    assert sensor.available is False
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -12,16 +12,20 @@ from unittest.mock import patch
 
 @pytest.mark.asyncio
 async def test_offset_sensor_handles_sensor_instance(hass):
-    net = NetHeatDemandSensor(
-        hass=hass,
-        name="Hourly Net Heat Demand",
-        unique_id="test_net",
-        area_m2=10.0,
-        energy_label="A",
-        indoor_sensor=None,
-        icon="mdi:test",
-        device=DeviceInfo(identifiers={("test", "1")}),
-    )
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        net = NetHeatDemandSensor(
+            hass=hass,
+            name="Hourly Net Heat Demand",
+            unique_id="test_net",
+            area_m2=10.0,
+            energy_label="A",
+            indoor_sensor=None,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "1")}),
+        )
 
     hass.states.async_set("sensor.price", "0.0")
 

--- a/tests/test_net_heat_demand_sensor.py
+++ b/tests/test_net_heat_demand_sensor.py
@@ -1,0 +1,37 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import NetHeatDemandSensor
+
+
+@pytest.mark.asyncio
+async def test_net_heat_demand_sensor_combines_sources(hass):
+    hass.states.async_set("sensor.outdoor", "10")
+    heat_loss = SimpleNamespace(extra_state_attributes={"forecast": [0.1, 0.2]})
+    window_gain = SimpleNamespace(
+        native_value=0.0,
+        extra_state_attributes={"forecast": [0.05, 0.05]},
+    )
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = NetHeatDemandSensor(
+            hass=hass,
+            name="Net Heat",
+            unique_id="nh1",
+            area_m2=10.0,
+            energy_label="A",
+            indoor_sensor=None,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "1")}),
+            heat_loss_sensor=heat_loss,
+            window_gain_sensor=window_gain,
+            outdoor_sensor="sensor.outdoor",
+        )
+    await sensor.async_update()
+    assert sensor.native_value == pytest.approx(0.066, rel=1e-3)
+    assert sensor.extra_state_attributes["forecast"] == [0.05, 0.15]
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_net_power_consumption_sensor.py
+++ b/tests/test_net_power_consumption_sensor.py
@@ -1,0 +1,41 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import NetPowerConsumptionSensor
+
+
+@pytest.mark.asyncio
+async def test_net_power_consumption_sensor_calculates_net(hass):
+    hass.states.async_set("sensor.c1", "10")
+    hass.states.async_set("sensor.c2", "5")
+    hass.states.async_set("sensor.p1", "3")
+    sensor = NetPowerConsumptionSensor(
+        hass=hass,
+        name="Net Power",
+        unique_id="np1",
+        consumption_sensors=["sensor.c1", "sensor.c2"],
+        production_sensors=["sensor.p1"],
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 12.0
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_net_power_consumption_sensor_ignores_invalid(hass):
+    hass.states.async_set("sensor.c1", "invalid")
+    hass.states.async_set("sensor.p1", "2")
+    sensor = NetPowerConsumptionSensor(
+        hass=hass,
+        name="Net Power",
+        unique_id="np2",
+        consumption_sensors=["sensor.c1"],
+        production_sensors=["sensor.p1"],
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == -2.0
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_outdoor_temperature_sensor.py
+++ b/tests/test_outdoor_temperature_sensor.py
@@ -3,15 +3,20 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.components.sensor import SensorStateClass
 
 from custom_components.heating_curve_optimizer.sensor import OutdoorTemperatureSensor
+from unittest.mock import patch
 
 
 @pytest.mark.asyncio
 async def test_outdoor_temperature_sensor_has_measurement_state_class(hass):
-    sensor = OutdoorTemperatureSensor(
-        hass=hass,
-        name="test",
-        unique_id="test",
-        device=DeviceInfo(identifiers={("test", "1")}),
-    )
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = OutdoorTemperatureSensor(
+            hass=hass,
+            name="test",
+            unique_id="test",
+            device=DeviceInfo(identifiers={("test", "1")}),
+        )
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     await sensor.async_will_remove_from_hass()

--- a/tests/test_quadratic_cop_sensor.py
+++ b/tests/test_quadratic_cop_sensor.py
@@ -1,0 +1,39 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import QuadraticCopSensor
+
+
+@pytest.mark.asyncio
+async def test_quadratic_cop_sensor_computes_value(hass):
+    hass.states.async_set("sensor.supply", "35")
+    hass.states.async_set("sensor.outdoor", "5")
+    sensor = QuadraticCopSensor(
+        hass=hass,
+        name="COP",
+        unique_id="cop1",
+        supply_sensor="sensor.supply",
+        outdoor_sensor="sensor.outdoor",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 4.2
+    assert sensor.available is True
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_quadratic_cop_sensor_handles_unavailable(hass):
+    hass.states.async_set("sensor.supply", "unknown")
+    hass.states.async_set("sensor.outdoor", "5")
+    sensor = QuadraticCopSensor(
+        hass=hass,
+        name="COP",
+        unique_id="cop2",
+        supply_sensor="sensor.supply",
+        outdoor_sensor="sensor.outdoor",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+    await sensor.async_update()
+    assert sensor.available is False
+    await sensor.async_will_remove_from_hass()

--- a/tests/test_window_solar_gain_sensor.py
+++ b/tests/test_window_solar_gain_sensor.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import WindowSolarGainSensor
+
+
+@pytest.mark.asyncio
+async def test_window_solar_gain_sensor_computes_gain(hass):
+    hass.states.async_set("sun.sun", "above_horizon", {"azimuth": 180, "elevation": 45})
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = WindowSolarGainSensor(
+            hass=hass,
+            name="Solar Gain",
+            unique_id="sg1",
+            east_m2=0.0,
+            west_m2=0.0,
+            south_m2=10.0,
+            u_value=1.2,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "1")}),
+        )
+        with patch.object(
+            sensor, "_fetch_radiation", AsyncMock(return_value=[100.0, 50.0])
+        ):
+            await sensor.async_update()
+    assert sensor.native_value == pytest.approx(0.589, rel=1e-3)
+    assert sensor.extra_state_attributes["forecast"][1] == pytest.approx(
+        0.295, rel=1e-3
+    )
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_window_solar_gain_sensor_handles_no_data(hass):
+    hass.states.async_set("sun.sun", "above_horizon", {"azimuth": 180, "elevation": 45})
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=None,
+    ):
+        sensor = WindowSolarGainSensor(
+            hass=hass,
+            name="Solar Gain",
+            unique_id="sg2",
+            east_m2=1.0,
+            west_m2=1.0,
+            south_m2=1.0,
+            u_value=1.2,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "2")}),
+        )
+        with patch.object(sensor, "_fetch_radiation", AsyncMock(return_value=[])):
+            await sensor.async_update()
+    assert sensor.native_value == 0.0
+    assert sensor.extra_state_attributes["forecast"] == []
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- add coverage for config flow and all missing sensors
- mock external dependencies for reliable unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959a772c98832391349beecf296412