### PR TITLE
Move listener setup for price sensor and add tests

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -179,10 +179,6 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
-
-    async def async_will_remove_from_hass(self):
-        await super().async_will_remove_from_hass()
-
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass,
@@ -190,6 +186,9 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
                 self._handle_price_change,
             )
         )
+
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
 
     async def _handle_price_change(self, event):
         new_state = event.data.get("new_state")

--- a/tests/test_current_electricity_price_sensor.py
+++ b/tests/test_current_electricity_price_sensor.py
@@ -58,3 +58,27 @@ async def test_price_sensor_has_measurement_state_class(hass):
     )
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_price_change_updates_sensor_state(hass):
+    """Verify that changes in the price sensor update the entity state."""
+    hass.states.async_set("sensor.price", "0.1")
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price4",
+        price_sensor="sensor.price",
+        source_type="Electricity consumption",
+        price_settings={},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "4")}),
+    )
+    await sensor.async_added_to_hass()
+    await sensor.async_update()
+    assert sensor.native_value == 0.1
+
+    hass.states.async_set("sensor.price", "0.2")
+    await hass.async_block_till_done()
+    assert sensor.native_value == 0.2
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- set up price sensor state-change listener during `async_added_to_hass`
- clean up listener with `async_on_remove`
- add regression test verifying entity updates on price changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895be0b8efc83238f835bc7960f7ff3