### PR TITLE
Add sensor error handling tests

### DIFF
--- a/tests/test_heat_loss_sensor.py
+++ b/tests/test_heat_loss_sensor.py
@@ -1,4 +1,6 @@
+import aiohttp
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -52,4 +54,69 @@ async def test_heat_loss_sensor_uses_outdoor_sensor_when_available(hass):
         await sensor.async_update()
     mock_fetch.assert_not_called()
     assert sensor.native_value == 0.096
+    await sensor.async_will_remove_from_hass()
+
+
+class _ErrorResponse:
+    def __init__(self, json_exc: Exception | None = None):
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc:
+            raise self._json_exc
+        return {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ErrorSession:
+    def __init__(self, get_exc: Exception | None = None, json_exc: Exception | None = None):
+        self._get_exc = get_exc
+        self._json_exc = json_exc
+
+    def get(self, *args, **kwargs):
+        if self._get_exc:
+            raise self._get_exc
+        return _ErrorResponse(self._json_exc)
+
+
+request_info = SimpleNamespace(real_url="http://test")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session",
+    [
+        _ErrorSession(get_exc=aiohttp.ClientError("network")),
+        _ErrorSession(
+            json_exc=aiohttp.ContentTypeError(
+                request_info=request_info, history=(), message="bad"
+            )
+        ),
+    ],
+    ids=["network_error", "json_error"],
+)
+async def test_heat_loss_sensor_handles_fetch_errors(hass, session):
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=session,
+    ):
+        sensor = HeatLossSensor(
+            hass=hass,
+            name="Heat Loss",
+            unique_id="hl_err",
+            area_m2=5.0,
+            energy_label="A",
+            indoor_sensor=None,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "err")}),
+        )
+        await sensor.async_update()
+    assert sensor.available is False
+    assert sensor.native_value == 0.0
+    assert sensor.extra_state_attributes == {}
     await sensor.async_will_remove_from_hass()

--- a/tests/test_outdoor_temperature_sensor.py
+++ b/tests/test_outdoor_temperature_sensor.py
@@ -1,4 +1,6 @@
+import aiohttp
 import pytest
+from types import SimpleNamespace
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.components.sensor import SensorStateClass
 
@@ -19,4 +21,65 @@ async def test_outdoor_temperature_sensor_has_measurement_state_class(hass):
             device=DeviceInfo(identifiers={("test", "1")}),
         )
     assert sensor.state_class == SensorStateClass.MEASUREMENT
+    await sensor.async_will_remove_from_hass()
+
+
+class _ErrorResponse:
+    def __init__(self, json_exc: Exception | None = None):
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc:
+            raise self._json_exc
+        return {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ErrorSession:
+    def __init__(self, get_exc: Exception | None = None, json_exc: Exception | None = None):
+        self._get_exc = get_exc
+        self._json_exc = json_exc
+
+    def get(self, *args, **kwargs):
+        if self._get_exc:
+            raise self._get_exc
+        return _ErrorResponse(self._json_exc)
+
+
+request_info = SimpleNamespace(real_url="http://test")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session",
+    [
+        _ErrorSession(get_exc=aiohttp.ClientError("network")),
+        _ErrorSession(
+            json_exc=aiohttp.ContentTypeError(
+                request_info=request_info, history=(), message="bad"
+            )
+        ),
+    ],
+    ids=["network_error", "json_error"],
+)
+async def test_outdoor_temperature_sensor_handles_fetch_errors(hass, session):
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=session,
+    ):
+        sensor = OutdoorTemperatureSensor(
+            hass=hass,
+            name="test",
+            unique_id="err",
+            device=DeviceInfo(identifiers={("test", "err")}),
+        )
+        await sensor.async_update()
+    assert sensor.available is False
+    assert sensor.native_value == 0.0
+    assert sensor.extra_state_attributes == {}
     await sensor.async_will_remove_from_hass()

--- a/tests/test_window_solar_gain_sensor.py
+++ b/tests/test_window_solar_gain_sensor.py
@@ -1,4 +1,6 @@
+import aiohttp
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -56,4 +58,70 @@ async def test_window_solar_gain_sensor_handles_no_data(hass):
             await sensor.async_update()
     assert sensor.native_value == 0.0
     assert sensor.extra_state_attributes["forecast"] == []
+    await sensor.async_will_remove_from_hass()
+
+
+class _ErrorResponse:
+    def __init__(self, json_exc: Exception | None = None):
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc:
+            raise self._json_exc
+        return {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ErrorSession:
+    def __init__(self, get_exc: Exception | None = None, json_exc: Exception | None = None):
+        self._get_exc = get_exc
+        self._json_exc = json_exc
+
+    def get(self, *args, **kwargs):
+        if self._get_exc:
+            raise self._get_exc
+        return _ErrorResponse(self._json_exc)
+
+
+request_info = SimpleNamespace(real_url="http://test")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session",
+    [
+        _ErrorSession(get_exc=aiohttp.ClientError("network")),
+        _ErrorSession(
+            json_exc=aiohttp.ContentTypeError(
+                request_info=request_info, history=(), message="bad"
+            )
+        ),
+    ],
+    ids=["network_error", "json_error"],
+)
+async def test_window_solar_gain_sensor_handles_fetch_errors(hass, session):
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
+        return_value=session,
+    ):
+        sensor = WindowSolarGainSensor(
+            hass=hass,
+            name="Solar Gain",
+            unique_id="sg_err",
+            east_m2=1.0,
+            west_m2=1.0,
+            south_m2=1.0,
+            u_value=1.2,
+            icon="mdi:test",
+            device=DeviceInfo(identifiers={("test", "err")}),
+        )
+        await sensor.async_update()
+    assert sensor.available is False
+    assert sensor.native_value == 0.0
+    assert sensor.extra_state_attributes == {}
     await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- add tests verifying sensors handle network and JSON errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895be1330048323998c163a5f48aaba