### PR TITLE
Remove unused unavailable grace constant

### DIFF
--- a/custom_components/heating_curve_optimizer/entity.py
+++ b/custom_components/heating_curve_optimizer/entity.py
@@ -14,9 +14,6 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
-# Seconds to wait before creating an unavailable issue
-UNAVAILABLE_GRACE_SECONDS = 60
-
 
 class BaseUtilitySensor(SensorEntity, RestoreEntity):
     def __init__(


### PR DESCRIPTION
## Summary
- remove unused `UNAVAILABLE_GRACE_SECONDS` constant

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/entity.py`
- `pytest -o addopts='' tests/test_config_flow.py` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_6895be1b4b208323b97fc4a0fd4f5337