### PR TITLE
Adjust electricity price with configurable markup and feed-in bonus

### DIFF
--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -23,6 +23,8 @@ from .const import (
     CONF_K_FACTOR,
     CONF_PRICE_SENSOR,
     CONF_PRICE_SETTINGS,
+    CONF_MARKUP,
+    CONF_FEED_IN_BONUS,
     DEFAULT_K_FACTOR,
     CONF_SOURCE_TYPE,
     CONF_SOURCES,
@@ -90,6 +92,7 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_CONFIGS: self.configs,
                         CONF_PRICE_SENSOR: self.price_settings.get(CONF_PRICE_SENSOR),
+                        CONF_PRICE_SETTINGS: self.price_settings,
                         CONF_AREA_M2: self.area_m2,
                         CONF_ENERGY_LABEL: self.energy_label,
                         CONF_GLASS_EAST_M2: self.glass_east_m2,
@@ -368,6 +371,14 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 }
             ),
+            vol.Optional(
+                CONF_MARKUP,
+                default=self.price_settings.get(CONF_MARKUP, 0.0),
+            ): vol.Coerce(float),
+            vol.Optional(
+                CONF_FEED_IN_BONUS,
+                default=self.price_settings.get(CONF_FEED_IN_BONUS, 0.0),
+            ): vol.Coerce(float),
         }
 
         return self.async_show_form(
@@ -462,6 +473,7 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                     data={
                         CONF_CONFIGS: self.configs,
                         CONF_PRICE_SENSOR: self.price_settings.get(CONF_PRICE_SENSOR),
+                        CONF_PRICE_SETTINGS: self.price_settings,
                         CONF_AREA_M2: self.area_m2,
                         CONF_ENERGY_LABEL: self.energy_label,
                         CONF_GLASS_EAST_M2: self.glass_east_m2,
@@ -654,6 +666,14 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                     }
                 }
             ),
+            vol.Optional(
+                CONF_MARKUP,
+                default=self.price_settings.get(CONF_MARKUP, 0.0),
+            ): vol.Coerce(float),
+            vol.Optional(
+                CONF_FEED_IN_BONUS,
+                default=self.price_settings.get(CONF_FEED_IN_BONUS, 0.0),
+            ): vol.Coerce(float),
         }
 
         return self.async_show_form(

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -11,6 +11,8 @@ CONF_SOURCE_TYPE = "source_type"
 CONF_SOURCES = "sources"
 CONF_PRICE_SENSOR = "price_sensor"
 CONF_PRICE_SETTINGS = "price_settings"
+CONF_MARKUP = "markup"
+CONF_FEED_IN_BONUS = "feed_in_bonus"
 
 # New configuration keys for the heating curve optimizer
 CONF_AREA_M2 = "area_m2"

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -174,8 +174,10 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             _LOGGER.warning("Price sensor %s has invalid state", self.price_sensor)
             return
         self._attr_available = True
-
-        self._attr_native_value = round(base_price, 8)
+        markup = float(self.price_settings.get("markup", 0) or 0)
+        feed_in_bonus = float(self.price_settings.get("feed_in_bonus", 0) or 0)
+        adjusted_price = base_price + markup - feed_in_bonus
+        self._attr_native_value = round(adjusted_price, 8)
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()

--- a/tests/test_current_electricity_price_sensor.py
+++ b/tests/test_current_electricity_price_sensor.py
@@ -82,3 +82,39 @@ async def test_price_change_updates_sensor_state(hass):
     await hass.async_block_till_done()
     assert sensor.native_value == 0.2
     await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_price_sensor_with_markup(hass):
+    hass.states.async_set("sensor.price", "0.1")
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price5",
+        price_sensor="sensor.price",
+        source_type="Electricity consumption",
+        price_settings={"markup": 0.05},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "5")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 0.15
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_price_sensor_with_feed_in_bonus(hass):
+    hass.states.async_set("sensor.price", "0.1")
+    sensor = CurrentElectricityPriceSensor(
+        hass=hass,
+        name="Electricity Price",
+        unique_id="price6",
+        price_sensor="sensor.price",
+        source_type="Electricity production",
+        price_settings={"feed_in_bonus": 0.02},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "6")}),
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 0.08
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- allow CurrentElectricityPriceSensor to apply configurable markup and feed-in bonus
- collect and store markup and feed-in bonus in config flow
- test price adjustments for positive markup and feed-in bonus

## Testing
- `pip install -r requirements.txt` (failed: conflicting dependencies)
- `pip install syrupy`
- `pip install pytest-cov`
- `pip install homeassistant`
- `pip install pytest-asyncio`
- `pip install pytest-homeassistant-custom-component`
- `pytest tests/test_current_electricity_price_sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c3d7276c83239f2b510122fa0ec7