### PR TITLE
Compensate energy consumption forecast for heat pump usage

### DIFF
--- a/tests/test_energy_consumption_forecast_sensor.py
+++ b/tests/test_energy_consumption_forecast_sensor.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.heating_curve_optimizer.sensor import EnergyConsumptionForecastSensor
+from custom_components.heating_curve_optimizer.sensor import (
+    EnergyConsumptionForecastSensor,
+)
 
 
 @pytest.mark.asyncio
@@ -29,8 +31,8 @@ async def test_fetch_history_multiple_entities(hass):
         "homeassistant.components.recorder.get_instance",
     ) as mock_get_instance:
         mock_recorder = AsyncMock()
-        mock_recorder.async_add_executor_job.side_effect = (
-            lambda func, *args: func(*args)
+        mock_recorder.async_add_executor_job.side_effect = lambda func, *args: func(
+            *args
         )
         mock_get_instance.return_value = mock_recorder
         data = await sensor._fetch_history(["sensor.c1", "sensor.c2"], start, end)
@@ -65,3 +67,38 @@ async def test_sensor_initializes_with_multiple_sources(hass):
         await sensor.async_update()
 
     assert sensor.native_value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_sensor_excludes_heatpump_consumption(hass):
+    sensor = EnergyConsumptionForecastSensor(
+        hass=hass,
+        name="test",
+        unique_id="test",
+        consumption_sensors=["sensor.grid"],
+        production_sensors=["sensor.solar"],
+        heatpump_sensor="sensor.hp",
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+
+    async def fake_fetch(sensors, start, end):  # noqa: ANN001
+        return {sensors[0]: []} if sensors else {}
+
+    def hourly_avg_side_effect(data):  # noqa: ANN001
+        if "sensor.grid" in data:
+            return [5.0] * 24
+        if "sensor.solar" in data:
+            return [1.0] * 24
+        if "sensor.hp" in data:
+            return [2.0] * 24
+        return [0.0] * 24
+
+    with patch("homeassistant.util.dt.utcnow", return_value=dt.datetime(2024, 1, 1)):
+        with patch.object(
+            sensor, "_fetch_history", side_effect=fake_fetch
+        ), patch.object(sensor, "_hourly_averages", side_effect=hourly_avg_side_effect):
+            await sensor.async_update()
+
+    assert sensor.native_value == 2.0
+    assert sensor.extra_state_attributes["standby_forecast"][0] == 2.0


### PR DESCRIPTION
## Summary
- exclude heat pump power from energy consumption forecast using historical averages
- add test to validate heat pump compensation logic

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_energy_consumption_forecast_sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b38760674832396b306af08511999