### PR TITLE
Add heating curve min/max number entities

### DIFF
--- a/custom_components/heating_curve_optimizer/number.py
+++ b/custom_components/heating_curve_optimizer/number.py
@@ -42,21 +42,123 @@ class HeatingCurveOffsetNumber(NumberEntity, RestoreEntity):
         self.async_write_ha_state()
 
 
+class HeatCurveMinNumber(NumberEntity, RestoreEntity):
+    """Number entity to represent the minimum heating curve temperature."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Heating Curve Min"
+    _attr_translation_key = "heating_curve_min"
+    _attr_native_unit_of_measurement = "°C"
+    _attr_native_step = 1.0
+    _attr_icon = "mdi:thermometer-low"
+
+    def __init__(
+        self,
+        unique_id: str,
+        device: DeviceInfo,
+        *,
+        native_min: float,
+        native_max: float,
+    ) -> None:
+        self._attr_unique_id = unique_id
+        self._attr_device_info = device
+        self._attr_native_min_value = native_min
+        self._attr_native_max_value = native_max
+        self._attr_native_value = native_min
+        self._attr_available = True
+
+    async def async_added_to_hass(self) -> None:  # pragma: no cover - simple restore
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in ("unknown", "unavailable"):
+            try:
+                self._attr_native_value = float(last_state.state)
+            except ValueError:
+                self._attr_native_value = self._attr_native_min_value
+        self.hass.data.setdefault(DOMAIN, {})["heat_curve_min"] = self._attr_native_value
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._attr_native_value = float(value)
+        self.hass.data.setdefault(DOMAIN, {})["heat_curve_min"] = self._attr_native_value
+        self.async_write_ha_state()
+
+
+class HeatCurveMaxNumber(NumberEntity, RestoreEntity):
+    """Number entity to represent the maximum heating curve temperature."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Heating Curve Max"
+    _attr_translation_key = "heating_curve_max"
+    _attr_native_unit_of_measurement = "°C"
+    _attr_native_step = 1.0
+    _attr_icon = "mdi:thermometer-high"
+
+    def __init__(
+        self,
+        unique_id: str,
+        device: DeviceInfo,
+        *,
+        native_min: float,
+        native_max: float,
+    ) -> None:
+        self._attr_unique_id = unique_id
+        self._attr_device_info = device
+        self._attr_native_min_value = native_min
+        self._attr_native_max_value = native_max
+        self._attr_native_value = native_max
+        self._attr_available = True
+
+    async def async_added_to_hass(self) -> None:  # pragma: no cover - simple restore
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in ("unknown", "unavailable"):
+            try:
+                self._attr_native_value = float(last_state.state)
+            except ValueError:
+                self._attr_native_value = self._attr_native_max_value
+        self.hass.data.setdefault(DOMAIN, {})["heat_curve_max"] = self._attr_native_value
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._attr_native_value = float(value)
+        self.hass.data.setdefault(DOMAIN, {})["heat_curve_max"] = self._attr_native_value
+        self.async_write_ha_state()
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Heating Curve Offset number entity."""
+    """Set up heating curve number entities."""
     device_info = DeviceInfo(
         identifiers={(DOMAIN, entry.entry_id)},
         name="Heating Curve Optimizer",
     )
-    number = HeatingCurveOffsetNumber(
+
+    offset = HeatingCurveOffsetNumber(
         unique_id=f"{entry.entry_id}_heating_curve_offset", device=device_info
     )
-    async_add_entities([number])
+    curve_min = HeatCurveMinNumber(
+        unique_id=f"{entry.entry_id}_heating_curve_min",
+        device=device_info,
+        native_min=20.0,
+        native_max=45.0,
+    )
+    curve_max = HeatCurveMaxNumber(
+        unique_id=f"{entry.entry_id}_heating_curve_max",
+        device=device_info,
+        native_min=35.0,
+        native_max=60.0,
+    )
+
+    async_add_entities([offset, curve_min, curve_max])
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault("entities", {})[number.entity_id] = number
+    hass.data[DOMAIN].setdefault("entities", {})[offset.entity_id] = offset
+    hass.data[DOMAIN]["heat_curve_min"] = curve_min.native_value
+    hass.data[DOMAIN]["heat_curve_max"] = curve_max.native_value
 
 
-__all__ = ["HeatingCurveOffsetNumber"]
+__all__ = [
+    "HeatingCurveOffsetNumber",
+    "HeatCurveMinNumber",
+    "HeatCurveMaxNumber",
+]


### PR DESCRIPTION
## Summary
- add `HeatCurveMinNumber` and `HeatCurveMaxNumber` configurable number entities
- register min/max entities alongside offset entity and persist their values in `hass.data`

## Testing
- `pytest -q` *(fails: No entity id specified for entity Electricity Price)*

------
https://chatgpt.com/codex/tasks/task_e_689d93ed59448323a3c8945e07ff4849