### PR TITLE
Add energy price level sensor

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -1458,7 +1458,9 @@ class EnergyPriceLevelSensor(BaseUtilitySensor):
         attrs: dict[str, float] = {}
         for level, threshold in sorted_levels:
             total = sum(
-                energy_forecast[i] for i in range(horizon) if price_forecast[i] <= threshold
+                energy_forecast[i]
+                for i in range(horizon)
+                if price_forecast[i] <= threshold
             )
             attrs[level] = round(total, 3)
 

--- a/tests/test_energy_price_level_sensor.py
+++ b/tests/test_energy_price_level_sensor.py
@@ -1,0 +1,35 @@
+import pytest
+from homeassistant.helpers.entity import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import EnergyPriceLevelSensor
+
+
+@pytest.mark.asyncio
+async def test_energy_price_level_sensor(hass):
+    hass.states.async_set(
+        "sensor.current_consumption_price",
+        "0.1",
+        {"forecast": [0.1, 0.2, 0.3]},
+    )
+    hass.states.async_set(
+        "sensor.expected_energy_consumption",
+        "0",
+        {"standby_forecast_net": [1.0, 1.0, 1.0]},
+    )
+    sensor = EnergyPriceLevelSensor(
+        hass=hass,
+        name="Available Energy by Price",
+        unique_id="avail1",
+        price_sensor="sensor.current_consumption_price",
+        forecast_sensor="sensor.expected_energy_consumption",
+        price_levels={"low": 0.15, "mid": 0.25, "high": 0.35},
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_update()
+    attrs = sensor.extra_state_attributes
+    assert attrs["low"] == 1.0
+    assert attrs["mid"] == 2.0
+    assert attrs["high"] == 3.0
+    assert sensor.native_value == 1.0
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- introduce EnergyPriceLevelSensor to compare forecasted consumption against configurable price thresholds
- expose available energy per price level and register sensor when price and forecast data exist
- add unit tests for price level sensor

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efd5d6e488323ac6ffc6a65e7b486