### PR TITLE
Add configurable COP parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Configuration is done entirely through the UI. The following options can be prov
 - A price sensor for electricity rates.
 - Optional multiple consumption and production sources.
 - The `k_factor` describing how the COP declines as the supply temperature rises.
+- The `base_cop` at 35 °C supply and 0 °C outdoor temperature.
+- The `outdoor_temp_coefficient` describing how the COP improves with outdoor temperature.
 
 ## Sensors
 | Sensor | Description |
@@ -32,7 +34,7 @@ Configuration is done entirely through the UI. The following options can be prov
 | `sensor.hourly_net_heat_demand` | Net heat demand after subtracting solar gain. |
 | `sensor.expected_energy_consumption` | Average standby power usage per hour. |
 | `sensor.current_net_consumption` | Current net power (consumption minus production). |
-| `sensor.heat_pump_cop` | COP derived from outdoor and supply temperature. |
+| `sensor.heat_pump_cop` | COP calculated as `base_cop + outdoor_temp_coefficient × outdoor_temp − k_factor × (supply_temp − 35)`. |
 | `sensor.heat_pump_thermal_power` | Current thermal output of the heat pump. |
 | `sensor.heating_curve_offset` | Optimal offset for the next six hours. |
 

--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -181,9 +181,7 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
             self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
             self.outdoor_temp_coeff = float(
-                user_input.get(
-                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
-                )
+                user_input.get(CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF)
             )
             return await self.async_step_user()
 
@@ -269,9 +267,7 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
             self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
             self.outdoor_temp_coeff = float(
-                user_input.get(
-                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
-                )
+                user_input.get(CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF)
             )
             return await self.async_step_user()
 
@@ -557,9 +553,7 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
             self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
             self.outdoor_temp_coeff = float(
-                user_input.get(
-                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
-                )
+                user_input.get(CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF)
             )
             return await self.async_step_user()
 

--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -21,9 +21,13 @@ from .const import (
     CONF_POWER_CONSUMPTION,
     CONF_SUPPLY_TEMPERATURE_SENSOR,
     CONF_K_FACTOR,
+    CONF_BASE_COP,
+    CONF_OUTDOOR_TEMP_COEFF,
     CONF_PRICE_SENSOR,
     CONF_PRICE_SETTINGS,
+    DEFAULT_COP_AT_35,
     DEFAULT_K_FACTOR,
+    DEFAULT_OUTDOOR_TEMP_COEFF,
     CONF_SOURCE_TYPE,
     CONF_SOURCES,
     DOMAIN,
@@ -59,6 +63,8 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.indoor_temperature_sensor: str | None = None
         self.supply_temperature_sensor: str | None = None
         self.k_factor: float | None = None
+        self.base_cop: float | None = None
+        self.outdoor_temp_coeff: float | None = None
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -100,6 +106,8 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_POWER_CONSUMPTION: self.power_consumption,
                         CONF_SUPPLY_TEMPERATURE_SENSOR: self.supply_temperature_sensor,
                         CONF_K_FACTOR: self.k_factor,
+                        CONF_BASE_COP: self.base_cop,
+                        CONF_OUTDOOR_TEMP_COEFF: self.outdoor_temp_coeff,
                     },
                 )
             self.source_type = choice
@@ -171,6 +179,12 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SUPPLY_TEMPERATURE_SENSOR
             )
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
+            self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
+            self.outdoor_temp_coeff = float(
+                user_input.get(
+                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
+                )
+            )
             return await self.async_step_user()
 
         power_sensors = await self._get_power_sensors()
@@ -225,6 +239,13 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_K_FACTOR, default=self.k_factor or DEFAULT_K_FACTOR
                 ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_BASE_COP, default=self.base_cop or DEFAULT_COP_AT_35
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_OUTDOOR_TEMP_COEFF,
+                    default=self.outdoor_temp_coeff or DEFAULT_OUTDOOR_TEMP_COEFF,
+                ): vol.Coerce(float),
             }
         )
 
@@ -246,6 +267,12 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SUPPLY_TEMPERATURE_SENSOR
             )
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
+            self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
+            self.outdoor_temp_coeff = float(
+                user_input.get(
+                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
+                )
+            )
             return await self.async_step_user()
 
         power_sensors = await self._get_power_sensors()
@@ -299,6 +326,13 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional(
                     CONF_K_FACTOR, default=self.k_factor or DEFAULT_K_FACTOR
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_BASE_COP, default=self.base_cop or DEFAULT_COP_AT_35
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_OUTDOOR_TEMP_COEFF,
+                    default=self.outdoor_temp_coeff or DEFAULT_OUTDOOR_TEMP_COEFF,
                 ): vol.Coerce(float),
             }
         )
@@ -406,6 +440,10 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_SUPPLY_TEMPERATURE_SENSOR
         )
         self.k_factor = config_entry.data.get(CONF_K_FACTOR)
+        self.base_cop = config_entry.data.get(CONF_BASE_COP, DEFAULT_COP_AT_35)
+        self.outdoor_temp_coeff = config_entry.data.get(
+            CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
+        )
         self.price_settings = copy.deepcopy(
             config_entry.options.get(
                 CONF_PRICE_SETTINGS,
@@ -472,6 +510,8 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_POWER_CONSUMPTION: self.power_consumption,
                         CONF_SUPPLY_TEMPERATURE_SENSOR: self.supply_temperature_sensor,
                         CONF_K_FACTOR: self.k_factor,
+                        CONF_BASE_COP: self.base_cop,
+                        CONF_OUTDOOR_TEMP_COEFF: self.outdoor_temp_coeff,
                     },
                 )
             self.source_type = choice
@@ -515,6 +555,12 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_SUPPLY_TEMPERATURE_SENSOR
             )
             self.k_factor = float(user_input.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
+            self.base_cop = float(user_input.get(CONF_BASE_COP, DEFAULT_COP_AT_35))
+            self.outdoor_temp_coeff = float(
+                user_input.get(
+                    CONF_OUTDOOR_TEMP_COEFF, DEFAULT_OUTDOOR_TEMP_COEFF
+                )
+            )
             return await self.async_step_user()
 
         power_sensors = await self._get_power_sensors()
@@ -583,6 +629,13 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_K_FACTOR, default=self.k_factor or DEFAULT_K_FACTOR
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_BASE_COP, default=self.base_cop or DEFAULT_COP_AT_35
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_OUTDOOR_TEMP_COEFF,
+                    default=self.outdoor_temp_coeff or DEFAULT_OUTDOOR_TEMP_COEFF,
                 ): vol.Coerce(float),
             }
         )

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -25,6 +25,8 @@ CONF_POWER_CONSUMPTION = "power_consumption"
 CONF_INDOOR_TEMPERATURE_SENSOR = "indoor_temperature_sensor"
 CONF_SUPPLY_TEMPERATURE_SENSOR = "supply_temperature_sensor"
 CONF_K_FACTOR = "k_factor"
+CONF_BASE_COP = "base_cop"
+CONF_OUTDOOR_TEMP_COEFF = "outdoor_temp_coefficient"
 
 # Allowed energy labels
 ENERGY_LABELS = ["A", "B", "C", "D", "E", "F", "G"]
@@ -45,6 +47,9 @@ INDOOR_TEMPERATURE = 21.0
 
 # Default COP at a supply temperature of 35 °C
 DEFAULT_COP_AT_35 = 4.2
+
+# Default increase in COP per °C outdoor temperature increase
+DEFAULT_OUTDOOR_TEMP_COEFF = 0.08
 
 # Default decline in COP per °C supply temperature increase
 DEFAULT_K_FACTOR = 0.11

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -728,9 +728,7 @@ class QuadraticCopSensor(BaseUtilitySensor):
             self._attr_available = False
             return
         cop = (
-            self.base_cop
-            + self.outdoor_coeff * o_temp
-            - self.k_factor * (s_temp - 35)
+            self.base_cop + self.outdoor_coeff * o_temp - self.k_factor * (s_temp - 35)
         )
         _LOGGER.debug(
             "Calculated COP with supply=%s outdoor=%s -> %s", s_temp, o_temp, cop
@@ -796,9 +794,7 @@ class HeatPumpThermalPowerSensor(BaseUtilitySensor):
             self._attr_available = False
             return
         cop = (
-            self.base_cop
-            + self.outdoor_coeff * o_temp
-            - self.k_factor * (s_temp - 35)
+            self.base_cop + self.outdoor_coeff * o_temp - self.k_factor * (s_temp - 35)
         )
         thermal_power = power * cop / 1000.0
         _LOGGER.debug(

--- a/custom_components/heating_curve_optimizer/translations/en.json
+++ b/custom_components/heating_curve_optimizer/translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "basic": {
+        "data": {
+          "base_cop": "Base COP at 35°C supply and 0°C outdoor",
+          "outdoor_temp_coefficient": "Outdoor temperature coefficient"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "heat_pump_cop": {
+        "name": "Heat Pump COP",
+        "state": {
+          "default": "COP = base_cop + outdoor_temp_coefficient × T_outdoor − k_factor × (T_supply − 35)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/heating_curve_optimizer/translations/nl.json
+++ b/custom_components/heating_curve_optimizer/translations/nl.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "basic": {
+        "data": {
+          "base_cop": "Basale COP bij 35°C aanvoer en 0°C buiten",
+          "outdoor_temp_coefficient": "Buitentemperatuur-coëfficiënt"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "heat_pump_cop": {
+        "name": "Warmtepomp COP",
+        "state": {
+          "default": "COP = basale_COP + buitentemperatuur-coëfficiënt × T_buiten − k-factor × (T_aanvoer − 35)"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_quadratic_cop_sensor.py
+++ b/tests/test_quadratic_cop_sensor.py
@@ -37,3 +37,24 @@ async def test_quadratic_cop_sensor_handles_unavailable(hass):
     await sensor.async_update()
     assert sensor.available is False
     await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_quadratic_cop_sensor_custom_params(hass):
+    hass.states.async_set("sensor.supply", "40")
+    hass.states.async_set("sensor.outdoor", "10")
+    sensor = QuadraticCopSensor(
+        hass=hass,
+        name="COP",
+        unique_id="cop3",
+        supply_sensor="sensor.supply",
+        outdoor_sensor="sensor.outdoor",
+        device=DeviceInfo(identifiers={("test", "3")}),
+        k_factor=0.1,
+        base_cop=5.0,
+        outdoor_coeff=0.05,
+    )
+    await sensor.async_update()
+    assert sensor.native_value == 5.0
+    assert sensor.available is True
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- allow configuring base COP and outdoor temperature coefficient
- apply custom COP parameters in COP and thermal power sensors
- document COP formula in README and translations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efd4e64f48323bea9bb134850f912