### PR TITLE
Add outdoor temperature limits for heating curve

### DIFF
--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -53,6 +53,7 @@ async def test_offset_sensor_sets_future_offsets_attribute(hass):
         "0.0",
         {"raw_today": [0.0] * 24, "raw_tomorrow": []},
     )
+    hass.states.async_set("sensor.outdoor_temperature", "0")
 
     sensor = HeatingCurveOffsetSensor(
         hass=hass,
@@ -80,6 +81,7 @@ async def test_offset_sensor_sets_future_offsets_attribute(hass):
         10,
         15,
     ]
+    assert "future_supply_temperatures" in sensor.extra_state_attributes
     await sensor.async_will_remove_from_hass()
 
 


### PR DESCRIPTION
## Summary
- add numbers for minimum and maximum outdoor temperatures
- track outdoor limits in hass.data alongside existing heating curve bounds
- use water and outdoor limits when computing supply temperature and optimizing offsets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efd4a19b48323a41dc8b453106e3d