### PR TITLE
Add A+, A++ and A+++ energy labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WARNING: Work In Progress!!
 ## Configuration
 Configuration is done entirely through the UI. The following options can be provided:
 - Home area in square meters (`area_m2`).
-- Energy label from A to G (`energy_label`).
+- Energy label from A+++ to G (`energy_label`).
 - Window areas facing east, west and south and the glass U‑value.
 - Optional indoor temperature, power consumption and supply temperature sensors.
 - A price sensor for electricity rates.

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -27,10 +27,13 @@ CONF_SUPPLY_TEMPERATURE_SENSOR = "supply_temperature_sensor"
 CONF_K_FACTOR = "k_factor"
 
 # Allowed energy labels
-ENERGY_LABELS = ["A", "B", "C", "D", "E", "F", "G"]
+ENERGY_LABELS = ["A+++", "A++", "A+", "A", "B", "C", "D", "E", "F", "G"]
 
 # Mapping energielabel -> U-waarde (W/m²K)
 U_VALUE_MAP = {
+    "A+++": 0.2,
+    "A++": 0.3,
+    "A+": 0.4,
     "A": 0.6,
     "B": 0.8,
     "C": 1.0,

--- a/custom_components/heating_curve_optimizer/translations/en.json
+++ b/custom_components/heating_curve_optimizer/translations/en.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "step": {
+      "basic": {
+        "data": {
+          "energy_label": "Energy label"
+        }
+      },
+      "user": {
+        "data": {
+          "energy_label": "Energy label"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/heating_curve_optimizer/translations/nl.json
+++ b/custom_components/heating_curve_optimizer/translations/nl.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "step": {
+      "basic": {
+        "data": {
+          "energy_label": "Energielabel"
+        }
+      },
+      "user": {
+        "data": {
+          "energy_label": "Energielabel"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,11 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-from custom_components.heating_curve_optimizer.const import DOMAIN, CONF_SOURCE_TYPE
+from custom_components.heating_curve_optimizer.const import (
+    DOMAIN,
+    CONF_SOURCE_TYPE,
+    CONF_ENERGY_LABEL,
+)
 from custom_components.heating_curve_optimizer.config_flow import STEP_BASIC
 
 
@@ -61,3 +65,24 @@ async def test_basic_options_step(hass: HomeAssistant):
         )
     assert result2["type"] == "form"
     assert result2["step_id"] == STEP_BASIC
+
+
+@pytest.mark.asyncio
+async def test_energy_labels_available(hass: HomeAssistant):
+    with patch(
+        "homeassistant.config_entries._load_integration", return_value=None
+    ), patch(
+        "homeassistant.loader.async_get_integration",
+        AsyncMock(
+            return_value=SimpleNamespace(domain=DOMAIN, single_config_entry=False)
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_SOURCE_TYPE: STEP_BASIC}
+        )
+
+    energy_label_field = result2["data_schema"].schema[CONF_ENERGY_LABEL]
+    assert "A+++" in energy_label_field.config["options"]


### PR DESCRIPTION
## Summary
- expand supported energy labels to include A+, A++ and A+++
- expose new labels through config flow and update docs/translations
- add test ensuring extended energy label list

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689efd385848832397ae62b54d52c33c