### PR TITLE
Rename net heat demand sensor to net heat loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WARNING: Work In Progress!!
 
 ## Overview
 - Retrieves weather and solar radiation data from *open-meteo.com*.
-- Estimates hourly heat loss and net heat demand for your home.
+- Estimates hourly heat loss and net heat loss for your home.
 - Creates sensors for electricity prices, consumption and production.
 - Predicts standby energy usage and current net power.
 - Optimizes the heating curve offset using a dynamic programming algorithm.
@@ -29,7 +29,7 @@ Configuration is done entirely through the UI. The following options can be prov
 | `sensor.current_production_price` | Current electricity price for production. |
 | `sensor.hourly_heat_loss` | Estimated heat loss in kW per hour. |
 | `sensor.window_solar_gain` | Expected solar gain through windows in kW. |
-| `sensor.hourly_net_heat_demand` | Net heat demand after subtracting solar gain. |
+| `sensor.hourly_net_heat_loss` | Net heat loss after subtracting solar gain. |
 | `sensor.expected_energy_consumption` | Average standby power usage per hour. |
 | `sensor.current_net_consumption` | Current net power (consumption minus production). |
 | `sensor.heat_pump_cop` | COP derived from outdoor and supply temperature. |

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -580,7 +580,7 @@ class WindowSolarGainSensor(BaseUtilitySensor):
         await super().async_will_remove_from_hass()
 
 
-class NetHeatDemandSensor(BaseUtilitySensor):
+class NetHeatLossSensor(BaseUtilitySensor):
     def __init__(
         self,
         hass: HomeAssistant,
@@ -662,7 +662,9 @@ class NetHeatDemandSensor(BaseUtilitySensor):
         q_loss = self.area_m2 * u_value * (indoor - t_outdoor) / 1000.0
         q_solar = solar_total
         q_net = q_loss - q_solar
-        _LOGGER.debug("Net heat demand loss=%s solar=%s net=%s", q_loss, q_solar, q_net)
+        _LOGGER.debug(
+            "Net heat loss: loss=%s solar=%s net=%s", q_loss, q_solar, q_net
+        )
         self._attr_native_value = round(q_net, 3)
 
         loss_fc = []
@@ -701,6 +703,9 @@ class NetHeatDemandSensor(BaseUtilitySensor):
 
     async def async_will_remove_from_hass(self):
         await super().async_will_remove_from_hass()
+
+
+NetHeatDemandSensor = NetHeatLossSensor
 
 
 class NetPowerConsumptionSensor(BaseUtilitySensor):
@@ -1969,10 +1974,10 @@ async def async_setup_entry(
 
     net_heat_sensor = None
     if area_m2 and energy_label:
-        net_heat_sensor = NetHeatDemandSensor(
+        net_heat_sensor = NetHeatLossSensor(
             hass=hass,
-            name="Hourly Net Heat Demand",
-            unique_id=f"{entry.entry_id}_hourly_net_heat_demand",
+            name="Hourly Net Heat Loss",
+            unique_id=f"{entry.entry_id}_hourly_net_heat_loss",
             area_m2=float(area_m2),
             energy_label=energy_label,
             indoor_sensor=indoor_sensor,

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.heating_curve_optimizer import sensor
 from custom_components.heating_curve_optimizer.sensor import (
     HeatingCurveOffsetSensor,
-    NetHeatDemandSensor,
+    NetHeatLossSensor,
 )
 from homeassistant.components.sensor import SensorStateClass
 
@@ -18,9 +18,9 @@ async def test_offset_sensor_handles_sensor_instance(hass):
         "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
         return_value=None,
     ):
-        net = NetHeatDemandSensor(
+        net = NetHeatLossSensor(
             hass=hass,
-            name="Hourly Net Heat Demand",
+            name="Hourly Net Heat Loss",
             unique_id="test_net",
             area_m2=10.0,
             energy_label="A",

--- a/tests/test_net_heat_loss_sensor.py
+++ b/tests/test_net_heat_loss_sensor.py
@@ -3,11 +3,11 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.heating_curve_optimizer.sensor import NetHeatDemandSensor
+from custom_components.heating_curve_optimizer.sensor import NetHeatLossSensor
 
 
 @pytest.mark.asyncio
-async def test_net_heat_demand_sensor_combines_sources(hass):
+async def test_net_heat_loss_sensor_combines_sources(hass):
     hass.states.async_set("sensor.outdoor", "10")
     heat_loss = SimpleNamespace(extra_state_attributes={"forecast": [0.1, 0.2]})
     window_gain = SimpleNamespace(
@@ -18,7 +18,7 @@ async def test_net_heat_demand_sensor_combines_sources(hass):
         "custom_components.heating_curve_optimizer.sensor.async_get_clientsession",
         return_value=None,
     ):
-        sensor = NetHeatDemandSensor(
+        sensor = NetHeatLossSensor(
             hass=hass,
             name="Net Heat",
             unique_id="nh1",


### PR DESCRIPTION
## Summary
- rename NetHeatDemandSensor to NetHeatLossSensor and expose Hourly Net Heat Loss entity
- keep NetHeatDemandSensor as backward-compatible alias
- update tests and documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0b9af1d883239643777dc80da482