### PR TITLE
Add power history sensor for consumption and production

### DIFF
--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -5,6 +5,7 @@ from functools import partial
 import logging
 import math
 from typing import Any, cast
+from datetime import datetime, timedelta
 
 import aiohttp
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -73,7 +74,7 @@ class OutdoorTemperatureSensor(BaseUtilitySensor):
             icon="mdi:thermometer",
             visible=True,
             device=device,
-            translation_key=name.lower().replace(" ", "_"),
+            translation_key=name.lower().replace(" ", "_").replace(".", "_"),
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
@@ -159,7 +160,7 @@ class SunIntensityPredictionSensor(BaseUtilitySensor):
             icon="mdi:white-balance-sunny",
             visible=True,
             device=device,
-            translation_key=name.lower().replace(" ", "_"),
+            translation_key=name.lower().replace(" ", "_").replace(".", "_"),
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self.hass = hass
@@ -773,6 +774,82 @@ class NetPowerConsumptionSensor(BaseUtilitySensor):
     async def _handle_change(self, event):
         self._compute_value()
         self.async_write_ha_state()
+
+
+class PowerHistorySensor(BaseUtilitySensor):
+    """Sensor recording the last 24 hours of a power source."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        name: str,
+        unique_id: str,
+        source_entity: str,
+        icon: str,
+        device: DeviceInfo,
+    ):
+        super().__init__(
+            name=name,
+            unique_id=unique_id,
+            unit="W",
+            device_class=None,
+            icon=icon,
+            visible=False,
+            device=device,
+            translation_key=name.lower().replace(" ", "_").replace(".", "_"),
+        )
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self.hass = hass
+        self.source_entity = source_entity
+        self._history: list[tuple[datetime, float]] = []
+
+    @property
+    def extra_state_attributes(self) -> dict[str, list[float]]:
+        now = datetime.utcnow()
+        cutoff = now - timedelta(hours=24)
+        self._history = [(ts, val) for ts, val in self._history if ts >= cutoff]
+        return {"history": [val for _, val in self._history]}
+
+    async def async_update(self):
+        state = self.hass.states.get(self.source_entity)
+        if state is None or state.state in ("unknown", "unavailable"):
+            self._attr_available = False
+            return
+        try:
+            self._attr_native_value = float(state.state)
+        except ValueError:
+            self._attr_available = False
+            return
+        self._attr_available = True
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self.source_entity, self._handle_change
+            )
+        )
+        state = self.hass.states.get(self.source_entity)
+        if state and state.state not in ("unknown", "unavailable"):
+            await self._process_state(state)
+
+    async def _handle_change(self, event):
+        state = event.data.get("new_state")
+        if state is not None:
+            await self._process_state(state)
+
+    async def _process_state(self, state):
+        try:
+            val = float(state.state)
+        except (ValueError, TypeError):
+            return
+        now = datetime.utcnow()
+        self._history.append((now, val))
+        cutoff = now - timedelta(hours=24)
+        self._history = [(ts, v) for ts, v in self._history if ts >= cutoff]
+        self._attr_native_value = val
+        if self.entity_id:
+            self.async_write_ha_state()
 
 
 class QuadraticCopSensor(BaseUtilitySensor):
@@ -1848,6 +1925,19 @@ async def async_setup_entry(
             consumption_sources.extend(cfg.get(CONF_SOURCES, []))
         elif cfg.get(CONF_SOURCE_TYPE) == SOURCE_TYPE_PRODUCTION:
             production_sources.extend(cfg.get(CONF_SOURCES, []))
+
+    for src in consumption_sources + production_sources:
+        slug = src.replace(".", "_")
+        entities.append(
+            PowerHistorySensor(
+                hass=hass,
+                name=f"{src} History",
+                unique_id=f"{entry.entry_id}_power_history_{slug}",
+                source_entity=src,
+                icon="mdi:history",
+                device=device_info,
+            )
+        )
 
     area_m2 = entry.data.get(CONF_AREA_M2)
     energy_label = entry.data.get(CONF_ENERGY_LABEL)

--- a/tests/test_power_history_sensor.py
+++ b/tests/test_power_history_sensor.py
@@ -1,0 +1,43 @@
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import PowerHistorySensor
+
+
+@pytest.mark.asyncio
+async def test_power_history_sensor_keeps_last_24h(hass):
+    sensor = PowerHistorySensor(
+        hass=hass,
+        name="History",
+        unique_id="ph1",
+        source_entity="sensor.source",
+        icon="mdi:test",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+
+    now = datetime(2024, 1, 1, 0, 0, 0)
+
+    class FakeDT(datetime):
+        @classmethod
+        def utcnow(cls):  # noqa: D401 - simple override
+            return now
+
+    with patch("custom_components.heating_curve_optimizer.sensor.datetime", FakeDT):
+        hass.states.async_set("sensor.source", "10")
+        await sensor.async_added_to_hass()
+        assert sensor.extra_state_attributes["history"] == [10.0]
+
+        now += timedelta(hours=23)
+        hass.states.async_set("sensor.source", "20")
+        await hass.async_block_till_done()
+        assert sensor.extra_state_attributes["history"] == [10.0, 20.0]
+
+        now += timedelta(hours=2)
+        hass.states.async_set("sensor.source", "30")
+        await hass.async_block_till_done()
+        assert sensor.extra_state_attributes["history"] == [20.0, 30.0]
+
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- track last 24 hours for each configured power sensor
- expose history via sensor attributes and test implementation

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_power_history_sensor.py`
- `pytest tests/test_power_history_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_689f0b8dbd648323ba9b629a83124fd7