### PR TITLE
Allow configuring outdoor temperature limits

### DIFF
--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -26,6 +26,8 @@ from .const import (
     CONF_K_FACTOR,
     CONF_BASE_COP,
     CONF_OUTDOOR_TEMP_COEFFICIENT,
+    CONF_HEAT_CURVE_MIN_OUTDOOR,
+    CONF_HEAT_CURVE_MAX_OUTDOOR,
     CONF_PRICE_SENSOR,
     CONF_PRICE_SETTINGS,
     DEFAULT_K_FACTOR,
@@ -73,6 +75,8 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.outdoor_temp_coefficient: float = DEFAULT_OUTDOOR_TEMP_COEFFICIENT
         self.planning_window: int = DEFAULT_PLANNING_WINDOW
         self.time_base: int = DEFAULT_TIME_BASE
+        self.heat_curve_min_outdoor: float = -20.0
+        self.heat_curve_max_outdoor: float = 15.0
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -119,6 +123,8 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_OUTDOOR_TEMP_COEFFICIENT: self.outdoor_temp_coefficient,
                         CONF_PLANNING_WINDOW: self.planning_window,
                         CONF_TIME_BASE: self.time_base,
+                        CONF_HEAT_CURVE_MIN_OUTDOOR: self.heat_curve_min_outdoor,
+                        CONF_HEAT_CURVE_MAX_OUTDOOR: self.heat_curve_max_outdoor,
                     },
                 )
             self.source_type = choice
@@ -203,6 +209,12 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_PLANNING_WINDOW, DEFAULT_PLANNING_WINDOW)
             )
             self.time_base = int(user_input.get(CONF_TIME_BASE, DEFAULT_TIME_BASE))
+            self.heat_curve_min_outdoor = float(
+                user_input.get(CONF_HEAT_CURVE_MIN_OUTDOOR, -20.0)
+            )
+            self.heat_curve_max_outdoor = float(
+                user_input.get(CONF_HEAT_CURVE_MAX_OUTDOOR, 15.0)
+            )
             return await self.async_step_user()
 
         power_sensors = await self._get_power_sensors()
@@ -285,6 +297,14 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_TIME_BASE,
                     default=self.time_base or DEFAULT_TIME_BASE,
                 ): vol.Coerce(int),
+                vol.Optional(
+                    CONF_HEAT_CURVE_MIN_OUTDOOR,
+                    default=self.heat_curve_min_outdoor,
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_HEAT_CURVE_MAX_OUTDOOR,
+                    default=self.heat_curve_max_outdoor,
+                ): vol.Coerce(float),
             }
         )
 
@@ -319,6 +339,12 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_PLANNING_WINDOW, DEFAULT_PLANNING_WINDOW)
             )
             self.time_base = int(user_input.get(CONF_TIME_BASE, DEFAULT_TIME_BASE))
+            self.heat_curve_min_outdoor = float(
+                user_input.get(CONF_HEAT_CURVE_MIN_OUTDOOR, -20.0)
+            )
+            self.heat_curve_max_outdoor = float(
+                user_input.get(CONF_HEAT_CURVE_MAX_OUTDOOR, 15.0)
+            )
             return await self.async_step_user()
 
         power_sensors = await self._get_power_sensors()
@@ -401,6 +427,14 @@ class HeatingCurveOptimizerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_TIME_BASE,
                     default=self.time_base or DEFAULT_TIME_BASE,
                 ): vol.Coerce(int),
+                vol.Optional(
+                    CONF_HEAT_CURVE_MIN_OUTDOOR,
+                    default=self.heat_curve_min_outdoor,
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_HEAT_CURVE_MAX_OUTDOOR,
+                    default=self.heat_curve_max_outdoor,
+                ): vol.Coerce(float),
             }
         )
 

--- a/custom_components/heating_curve_optimizer/const.py
+++ b/custom_components/heating_curve_optimizer/const.py
@@ -34,6 +34,8 @@ CONF_OUTDOOR_TEMPERATURE_SENSOR = "outdoor_temperature_sensor"
 CONF_K_FACTOR = "k_factor"
 CONF_BASE_COP = "base_cop"
 CONF_OUTDOOR_TEMP_COEFFICIENT = "outdoor_temp_coefficient"
+CONF_HEAT_CURVE_MIN_OUTDOOR = "heat_curve_min_outdoor"
+CONF_HEAT_CURVE_MAX_OUTDOOR = "heat_curve_max_outdoor"
 
 # Allowed energy labels
 ENERGY_LABELS = ["A+++", "A++", "A+", "A", "B", "C", "D", "E", "F", "G"]

--- a/custom_components/heating_curve_optimizer/sensor.py
+++ b/custom_components/heating_curve_optimizer/sensor.py
@@ -1007,13 +1007,19 @@ class CalculatedSupplyTemperatureSensor(BaseUtilitySensor):
         try:
             min_temp = float(self.hass.data[DOMAIN]["heat_curve_min"])
             max_temp = float(self.hass.data[DOMAIN]["heat_curve_max"])
+            outdoor_min = float(self.hass.data[DOMAIN]["heat_curve_min_outdoor"])
+            outdoor_max = float(self.hass.data[DOMAIN]["heat_curve_max_outdoor"])
         except (KeyError, TypeError, ValueError):
             self._attr_available = False
             return
 
-        t_out = max(-15.0, min(20.0, outdoor))
-        ratio = (20.0 - t_out) / 35.0
-        base = min_temp + (max_temp - min_temp) * ratio
+        base = _calculate_supply_temperature(
+            outdoor,
+            water_min=min_temp,
+            water_max=max_temp,
+            outdoor_min=outdoor_min,
+            outdoor_max=outdoor_max,
+        )
         target = base + offset
 
         _LOGGER.debug(

--- a/tests/test_supply_temperature_sensor.py
+++ b/tests/test_supply_temperature_sensor.py
@@ -12,7 +12,12 @@ from custom_components.heating_curve_optimizer.const import DOMAIN
 async def test_calculated_supply_temperature_sensor(hass):
     hass.states.async_set("sensor.outdoor_temp", "0")
     hass.states.async_set("number.heating_curve_offset", "2")
-    hass.data[DOMAIN] = {"heat_curve_min": 30.0, "heat_curve_max": 50.0}
+    hass.data[DOMAIN] = {
+        "heat_curve_min": 30.0,
+        "heat_curve_max": 50.0,
+        "heat_curve_min_outdoor": -20.0,
+        "heat_curve_max_outdoor": 15.0,
+    }
 
     sensor = CalculatedSupplyTemperatureSensor(
         hass=hass,
@@ -25,14 +30,19 @@ async def test_calculated_supply_temperature_sensor(hass):
 
     await sensor.async_update()
     assert sensor.available is True
-    assert sensor.native_value == pytest.approx(43.429, rel=1e-3)
+    assert sensor.native_value == pytest.approx(40.571, rel=1e-3)
 
 
 @pytest.mark.asyncio
 async def test_optimized_supply_temperature_sensor(hass):
     hass.states.async_set("sensor.outdoor_temp", "0")
     hass.states.async_set("sensor.heating_curve_offset", "-1")
-    hass.data[DOMAIN] = {"heat_curve_min": 30.0, "heat_curve_max": 50.0}
+    hass.data[DOMAIN] = {
+        "heat_curve_min": 30.0,
+        "heat_curve_max": 50.0,
+        "heat_curve_min_outdoor": -20.0,
+        "heat_curve_max_outdoor": 15.0,
+    }
 
     sensor = OptimizedSupplyTemperatureSensor(
         hass=hass,
@@ -45,4 +55,4 @@ async def test_optimized_supply_temperature_sensor(hass):
 
     await sensor.async_update()
     assert sensor.available is True
-    assert sensor.native_value == pytest.approx(40.429, rel=1e-3)
+    assert sensor.native_value == pytest.approx(37.571, rel=1e-3)


### PR DESCRIPTION
## Summary
- add configuration keys for heat curve outdoor temperature bounds
- allow configuring outdoor temperature limits via config flow
- base number entities and supply temperature calculation on configured outdoor bounds

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/const.py custom_components/heating_curve_optimizer/config_flow.py custom_components/heating_curve_optimizer/number.py custom_components/heating_curve_optimizer/sensor.py tests/test_supply_temperature_sensor.py`
- `pre-commit run --files custom_components/heating_curve_optimizer/number.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0b8caeb88323906603e87dd9e893