### PR TITLE
Add heat pump power history sensor

### DIFF
--- a/tests/test_heat_pump_power_history_sensor.py
+++ b/tests/test_heat_pump_power_history_sensor.py
@@ -1,0 +1,32 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.heating_curve_optimizer.sensor import (
+    HeatPumpPowerHistorySensor,
+)
+
+
+@pytest.mark.asyncio
+async def test_heat_pump_power_history_sensor_records_history(hass):
+    hass.states.async_set("sensor.hp_power", "500")
+    sensor = HeatPumpPowerHistorySensor(
+        hass=hass,
+        name="Heat Pump Power History",
+        unique_id="hph1",
+        power_sensor="sensor.hp_power",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+    await sensor.async_added_to_hass()
+    history = sensor.extra_state_attributes["history"]
+    assert sensor.native_value == 500.0
+    assert len(history) == 1
+    assert history[0]["power"] == 500.0
+
+    hass.states.async_set("sensor.hp_power", "600")
+    await hass.async_block_till_done()
+    history = sensor.extra_state_attributes["history"]
+    assert sensor.native_value == 600.0
+    assert len(history) == 2
+    assert history[-1]["power"] == 600.0
+
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- track heat pump power readings over time
- register power history sensor when a power sensor is configured
- cover new sensor with unit test

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heat_pump_power_history_sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0b8ebc0c832399ab3b23ed6a4e5d