### PR TITLE
Add HeatBufferSensor for heat buffer evolution

### DIFF
--- a/tests/test_heat_buffer_sensor.py
+++ b/tests/test_heat_buffer_sensor.py
@@ -1,0 +1,44 @@
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.components.sensor import SensorStateClass
+
+from custom_components.heating_curve_optimizer.sensor import HeatBufferSensor
+
+
+@pytest.mark.asyncio
+async def test_heat_buffer_sensor_reads_evolution(hass):
+    hass.states.async_set(
+        "sensor.heating_curve_offset", "0", {"buffer_evolution": [0, 1, 2]}
+    )
+
+    sensor = HeatBufferSensor(
+        hass=hass,
+        name="Heat Buffer",
+        unique_id="buffer1",
+        offset_entity="sensor.heating_curve_offset",
+        device=DeviceInfo(identifiers={("test", "1")}),
+    )
+
+    await sensor.async_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 0
+    assert sensor.extra_state_attributes["buffer_evolution"] == [0, 1, 2]
+    assert sensor.extra_state_attributes["buffer_by_step"] == {"0": 0, "1": 1, "2": 2}
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    await sensor.async_will_remove_from_hass()
+
+
+@pytest.mark.asyncio
+async def test_heat_buffer_sensor_unavailable_without_offset(hass):
+    sensor = HeatBufferSensor(
+        hass=hass,
+        name="Heat Buffer",
+        unique_id="buffer2",
+        offset_entity="sensor.missing_offset",
+        device=DeviceInfo(identifiers={("test", "2")}),
+    )
+
+    await sensor.async_update()
+    assert sensor.available is False
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- add HeatBufferSensor that exposes buffer evolution data
- register HeatBufferSensor during setup
- add tests for HeatBufferSensor

## Testing
- `pre-commit run --files custom_components/heating_curve_optimizer/sensor.py tests/test_heat_buffer_sensor.py`
- `pytest tests/test_heat_buffer_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_689f10585c848323ab74a5e8542384d7