### PR TITLE
Use historical energy trends to adjust heat demand

### DIFF
--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -144,3 +144,48 @@ async def test_offset_sensor_respects_time_base(hass):
 
     assert len(sensor.extra_state_attributes["future_offsets"]) == 4
     assert len(sensor.extra_state_attributes["prices"]) == 4
+
+
+class DummyHistorySensor:
+    def __init__(self, history):
+        self._history = history
+
+    @property
+    def extra_state_attributes(self):
+        return {"history": self._history}
+
+
+@pytest.mark.asyncio
+async def test_offset_sensor_includes_history_in_demand(hass):
+    hass.states.async_set("sensor.net_heat", "1", {"forecast": [1.0] * 6})
+    hass.states.async_set(
+        "sensor.price",
+        "0.0",
+        {"raw_today": [0.0] * 24, "raw_tomorrow": []},
+    )
+    hass.states.async_set("sensor.outdoor_temperature", "0")
+
+    power_hist = DummyHistorySensor([1000, 2000])
+    heatpump_hist = DummyHistorySensor([{"power": 3000}, {"power": 5000}])
+    solar_hist = DummyHistorySensor([500, 500])
+
+    sensor = HeatingCurveOffsetSensor(
+        hass=hass,
+        name="Heating Curve Offset",
+        unique_id="offset_hist",
+        net_heat_sensor="sensor.net_heat",
+        price_sensor="sensor.price",
+        device=DeviceInfo(identifiers={("test", "hist")}),
+        power_history_sensors=[power_hist],
+        heatpump_history_sensor=heatpump_hist,
+        solar_history_sensor=solar_hist,
+    )
+
+    with patch(
+        "custom_components.heating_curve_optimizer.sensor._optimize_offsets",
+        return_value=([0] * 6, [0] * 6),
+    ) as mock_opt:
+        await sensor.async_update()
+
+    assert mock_opt.call_args[0][0] == [6.0] * 6
+    await sensor.async_will_remove_from_hass()


### PR DESCRIPTION
## Summary
- factor in power, heat pump, and solar histories when estimating net heat demand
- wire history sensors into heating curve offset sensor
- test demand adjustment with simulated historical datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f105a437883238708b1440f3128d6