### PR TITLE
Fix price sensor default display in options flow

### DIFF
--- a/custom_components/heating_curve_optimizer/config_flow.py
+++ b/custom_components/heating_curve_optimizer/config_flow.py
@@ -547,6 +547,11 @@ class HeatingCurveOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                 {},
             )
         )
+        if (
+            (price_sensor := _get(CONF_PRICE_SENSOR))
+            and CONF_PRICE_SENSOR not in self.price_settings
+        ):
+            self.price_settings[CONF_PRICE_SENSOR] = price_sensor
         self.source_type: str | None = None
         self.sources: list[str] | None = None
 


### PR DESCRIPTION
## Summary
- retain the previously selected price sensor when re-opening the options flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4cefcf8688323b2dafce06b44dcd1