### PR TITLE
Ensure forecast time bases align across heating optimizer sensors

### DIFF
--- a/tests/test_heat_loss_sensor.py
+++ b/tests/test_heat_loss_sensor.py
@@ -26,6 +26,7 @@ async def test_heat_loss_sensor_uses_outdoor_sensor(hass):
     await sensor.async_update()
     assert sensor.native_value == 0.096
     assert sensor.extra_state_attributes["forecast"] == [0.102, 0.09]
+    assert sensor.extra_state_attributes["forecast_time_base"] == 60
     await sensor.async_will_remove_from_hass()
 
 

--- a/tests/test_net_heat_loss_sensor.py
+++ b/tests/test_net_heat_loss_sensor.py
@@ -30,4 +30,5 @@ async def test_net_heat_loss_sensor_combines_sources(hass):
     await sensor.async_update()
     assert sensor.native_value == pytest.approx(0.066, rel=1e-3)
     assert sensor.extra_state_attributes["forecast"] == [0.05, 0.15]
+    assert sensor.extra_state_attributes["forecast_time_base"] == 60
     await sensor.async_will_remove_from_hass()

--- a/tests/test_window_solar_gain_sensor.py
+++ b/tests/test_window_solar_gain_sensor.py
@@ -35,6 +35,8 @@ async def test_window_solar_gain_sensor_computes_gain(hass):
     )
     assert sensor.extra_state_attributes["radiation_forecast"] == [100.0, 50.0]
     assert sensor.extra_state_attributes["radiation_history"] == [100.0]
+    assert sensor.extra_state_attributes["forecast_time_base"] == 60
+    assert sensor.extra_state_attributes["radiation_forecast_time_base"] == 60
     await sensor.async_will_remove_from_hass()
 
 
@@ -62,6 +64,8 @@ async def test_window_solar_gain_sensor_handles_no_data(hass):
     assert sensor.extra_state_attributes["forecast"] == []
     assert sensor.extra_state_attributes["radiation_forecast"] == []
     assert sensor.extra_state_attributes["radiation_history"] == [0.0]
+    assert sensor.extra_state_attributes["forecast_time_base"] == 60
+    assert sensor.extra_state_attributes["radiation_forecast_time_base"] == 60
     await sensor.async_will_remove_from_hass()
 
 


### PR DESCRIPTION
## Summary
- add a shared helper to normalize time-base metadata and expose 60-minute bases on outdoor, heat loss, window gain, and net heat forecasts
- warn about and record time-base mismatches while resampling forecasts in the heating curve offset and diagnostics sensors
- expand unit tests to validate the new time-base attributes and mismatch reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f86a50c88323a2e8feb6288c9285