### PR TITLE
Convert heat buffer to energy tracking

### DIFF
--- a/tests/test_heat_buffer_sensor.py
+++ b/tests/test_heat_buffer_sensor.py
@@ -8,7 +8,9 @@ from custom_components.heating_curve_optimizer.sensor import HeatBufferSensor
 @pytest.mark.asyncio
 async def test_heat_buffer_sensor_reads_evolution(hass):
     hass.states.async_set(
-        "sensor.heating_curve_offset", "0", {"buffer_evolution": [0, 1, 2]}
+        "sensor.heating_curve_offset",
+        "0",
+        {"buffer_evolution": [0.0, 1.5, 3.0]},
     )
 
     sensor = HeatBufferSensor(
@@ -22,9 +24,13 @@ async def test_heat_buffer_sensor_reads_evolution(hass):
     await sensor.async_update()
 
     assert sensor.available is True
-    assert sensor.native_value == 0
-    assert sensor.extra_state_attributes["buffer_evolution"] == [0, 1, 2]
-    assert sensor.extra_state_attributes["buffer_by_step"] == {"0": 0, "1": 1, "2": 2}
+    assert sensor.native_value == 0.0
+    assert sensor.extra_state_attributes["buffer_evolution"] == [0.0, 1.5, 3.0]
+    assert sensor.extra_state_attributes["buffer_by_step"] == {
+        "0": 0.0,
+        "1": 1.5,
+        "2": 3.0,
+    }
     assert sensor.state_class == SensorStateClass.MEASUREMENT
     await sensor.async_will_remove_from_hass()
 

--- a/tests/test_heating_curve_offset_sensor.py
+++ b/tests/test_heating_curve_offset_sensor.py
@@ -75,6 +75,14 @@ async def test_offset_sensor_sets_future_offsets_attribute(hass):
     assert sensor.extra_state_attributes["future_offsets"] == [1, 2, 3, 4, 5, 6]
     assert sensor.extra_state_attributes["prices"] == [0.0] * 6
     assert sensor.extra_state_attributes["buffer_evolution"] == [
+        0.5,
+        1.5,
+        3.0,
+        5.0,
+        7.5,
+        10.5,
+    ]
+    assert sensor.extra_state_attributes["buffer_evolution_offsets"] == [
         0,
         1,
         3,


### PR DESCRIPTION
## Summary
- convert the heating curve buffer evolution to represent stored energy in kWh
- expose the original offset evolution alongside the energy values and update the heat buffer sensor to report energy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e50d0716708323b5917d06d4d574db